### PR TITLE
feature (watchlist): implemented add/remove tickers from Screener and Ticker detail

### DIFF
--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -1,31 +1,58 @@
-import { Table, Badge } from 'react-bootstrap'
-import { Link } from 'react-router-dom'
-import type { TickerRow } from '../../../lib/types'
+import { Table, Badge, Button } from 'react-bootstrap';
+import { Link } from 'react-router-dom';
+import type { TickerRow } from '../../../lib/types';
+import { useWatchlist } from '../../watchlists/useWatchlist';
 
 export default function ScreenerTable({ rows }: { rows: TickerRow[] }) {
+
+  const { add, remove, has } = useWatchlist();
+
   return (
     <Table striped bordered hover variant="dark" size="sm" responsive>
       <thead>
         <tr>
-          <th>Ticker</th><th>Price</th><th>%</th>
-          <th>SI% (Public)</th><th>SI% (Broad)</th><th>DTC</th><th>RVOL</th><th>Catalyst</th>
+          <th>Ticker</th>
+          <th>Price</th>
+          <th>%</th>
+          <th>SI% (Public)</th>
+          <th>SI% (Broad)</th>
+          <th>DTC</th>
+          <th>RVOL</th>
+          <th>Catalyst</th>
+          <th>Watch</th>
         </tr>
       </thead>
       <tbody>
-        {rows.map(r => (
-          <tr key={r.ticker}>
-            <td><Link to={`/ticker/${r.ticker}`}>{r.ticker}</Link></td>
-            <td>{r.price.toFixed(2)}</td>
-            <td className={r.pctChange >= 0 ? 'text-success' : 'text-danger'}>
-              {r.pctChange.toFixed(2)}
-            </td>
-            <td>{r.siPublic.toFixed(1)}</td>
-            <td>{r.siBroad.toFixed(1)}</td>
-            <td>{r.dtc.toFixed(1)}</td>
-            <td>{r.rvol.toFixed(1)}</td>
-            <td>{r.catalyst ? <Badge bg="warning" text="dark">Yes</Badge> : '—'}</td>
-          </tr>
-        ))}
+        {rows.map(r => {
+
+          const tracked = has(r.ticker);
+
+          return (
+            <tr key={r.ticker}>
+              <td><Link to={`/ticker/${r.ticker}`}>{r.ticker}</Link></td>
+              <td>{r.price.toFixed(2)}</td>
+              <td className={r.pctChange >= 0 ? 'text-success' : 'text-danger'}>
+                {r.pctChange.toFixed(2)}
+              </td>
+              <td>{r.siPublic.toFixed(1)}</td>
+              <td>{r.siBroad.toFixed(1)}</td>
+              <td>{r.dtc.toFixed(1)}</td>
+              <td>{r.rvol.toFixed(1)}</td>
+              <td>{r.catalyst ? <Badge bg="warning" text="dark">Yes</Badge> : '—'}</td>
+              <td>
+                {tracked ? (
+                  <Button size="sm" variant="outline-warning" onClick={() => remove(r.ticker)}>
+                    Remove
+                  </Button>
+                ) : (
+                  <Button size="sm" variant="outline-info" onClick={() => add(r.ticker)}>
+                    Add
+                  </Button>
+                )}
+              </td>
+            </tr>
+          );
+        })}
       </tbody>
     </Table>
   )


### PR DESCRIPTION
## Summary
Implements the ability to add and remove tickers from a persistent watchlist.  
- Added `useWatchlist` hook backed by localStorage  
- Updated Screener table with Add/Remove buttons  
- Added toggle button on Ticker detail page  
- Watchlist page now reflects changes and persists across refreshes

## Linked Issue
Closes #2 

## Checklist
- [x] Add/remove buttons toggle watchlist correctly
- [x] LocalStorage persistence verified
- [x] Watchlist page updates dynamically
- [ ] No console errors or warnings
- [ ] Documentation updated
