### PR TITLE
feat(screener): sticky header with sort indicators and focus states

### DIFF
--- a/src/features/tickers/ScreenerPage.tsx
+++ b/src/features/tickers/ScreenerPage.tsx
@@ -18,12 +18,14 @@ import {
 
 function sortKeyToField(k: SortKey): keyof TickerRow {
   switch (k) {
-    case 'siPublic': return 'siPublic'
-    case 'dtc': return 'dtc'
-    case 'rvol': return 'rvol'
-    case 'pctChange': return 'pctChange'
+    case 'siPublic': return 'siPublic';
+    case 'siBroad': return 'siBroad';
+    case 'dtc': return 'dtc';
+    case 'rvol': return 'rvol';
+    case 'pctChange': return 'pctChange';
+    case 'price': return 'price';
     case 'ticker':
-    default: return 'ticker'
+    default: return 'ticker';
   }
 }
 
@@ -155,26 +157,28 @@ export default function ScreenerPage() {
             <Form.Label>Sort</Form.Label>
             <Form.Select {...form.register('sort')}>
               <option value="ticker">Ticker</option>
-              <option value="rvol">RVOL</option>
               <option value="siPublic">SI% Public</option>
+              <option value="siBroad">SI% Broad</option>
+              <option value="rvol">RVOL</option>
               <option value="dtc">DTC</option>
               <option value="pctChange">% Change</option>
+              <option value="price">Price</option>
             </Form.Select>
           </Col>
           <Col md="auto">
             <Form.Label>Sort Direction</Form.Label>
             <div>
               <Button
-                variant={watched.dir === 'desc' ? 'primary' : 'secondary'}
-                size="sm"
-                className="me-2"
-                onClick={() => form.setValue('dir', 'desc')}
-              >Desc</Button>
-              <Button
                 variant={watched.dir === 'asc' ? 'primary' : 'secondary'}
                 size="sm"
+                className="me-2"
                 onClick={() => form.setValue('dir', 'asc')}
               >Asc</Button>
+              <Button
+                variant={watched.dir === 'desc' ? 'primary' : 'secondary'}
+                size="sm"
+                onClick={() => form.setValue('dir', 'desc')}
+              >Desc</Button>
             </div>
           </Col>
         </Row>

--- a/src/features/tickers/ScreenerPage.tsx
+++ b/src/features/tickers/ScreenerPage.tsx
@@ -34,8 +34,8 @@ function valuesFromParams(params: URLSearchParams): ScreenerValues {
     dtcMin: params.get('dtcMin') ?? '0',
     rvolMin: params.get('rvolMin') ?? '0',
     catalyst: params.get('catalyst') === '1' ? 'true' : 'false',
-    sort: (params.get('sort') ?? 'rvol') as SortKey,
-    dir: (params.get('dir') ?? 'desc') as Dir,
+    sort: (params.get('sort') ?? 'ticker') as SortKey,
+    dir: (params.get('dir') ?? 'asc') as Dir,
   }
   // 1) Coerce & default from URL
   const coerced = ScreenerInputSchema.parse(raw)
@@ -154,11 +154,11 @@ export default function ScreenerPage() {
           <Col md={2}>
             <Form.Label>Sort</Form.Label>
             <Form.Select {...form.register('sort')}>
+              <option value="ticker">Ticker</option>
               <option value="rvol">RVOL</option>
               <option value="siPublic">SI% Public</option>
               <option value="dtc">DTC</option>
               <option value="pctChange">% Change</option>
-              <option value="ticker">Ticker</option>
             </Form.Select>
           </Col>
           <Col md="auto">

--- a/src/features/tickers/ScreenerPage.tsx
+++ b/src/features/tickers/ScreenerPage.tsx
@@ -45,18 +45,18 @@ function valuesFromParams(params: URLSearchParams): ScreenerValues {
 
 export default function ScreenerPage() {
   // --- data ---
-  const { data, isLoading, error } = useQuery({
+  const { data, isLoading, error } = useQuery<TickerRow[] | { rows: TickerRow[] }>({
     queryKey: ['tickers'],
     queryFn: async () => (await api.get<TickerRow[]>('/tickers')).data,
-  })
+  });
 
-  // --- URL <-> form state ---
+  // --- URL <-> form state (single source of truth for sorting/filtering) ---
   const [params, setParams] = useSearchParams()
   const form = useForm<ScreenerValues>({
     defaultValues: valuesFromParams(params),
     resolver: zodResolver(ScreenerFormSchema), // <-- uses the required schema
     mode: 'onChange',
-  })
+  });
 
   // Reflect form changes into URL
   React.useEffect(() => {
@@ -75,34 +75,51 @@ export default function ScreenerPage() {
     return () => sub.unsubscribe()
   }, [form, setParams])
 
-  // --- derived table data ---
+  // onSort handler - updates the form
+  const onSort = React.useCallback((col: SortKey) => {
+    const cur = form.getValues();
+    if (col === cur.sort) {
+      form.setValue('dir', cur.dir === 'asc' ? 'desc' : 'asc');
+    } else {
+      form.setValue('sort', col);
+      form.setValue('dir', 'asc');
+    }
+  }, [form]);
+
+  // --- derived table data (filter + sort) ---
   const watched = form.watch()
   const filtered = React.useMemo(() => {
-    const rows = data ?? [] // moved *inside* useMemo to appease eslint react-hooks deps
-    const { q, siMin, dtcMin, rvolMin, catalyst, sort, dir } = watched
+    const rows: TickerRow[] = Array.isArray(data)
+      ? data
+      : Array.isArray(data?.rows)
+        ? data?.rows
+        : [];
+
+    const { q, siMin, dtcMin, rvolMin, catalyst, sort, dir } = watched;
 
     let out = rows
       .filter(r => !q || r.ticker.toLowerCase().includes(q.toLowerCase()))
       .filter(r => r.siPublic >= siMin)
       .filter(r => r.dtc >= dtcMin)
       .filter(r => r.rvol >= rvolMin)
-      .filter(r => !catalyst || r.catalyst)
+      .filter(r => !catalyst || r.catalyst);
 
-    const key: keyof TickerRow = sortKeyToField(sort)
-    const order = dir === 'asc' ? 1 : -1
+    const key: keyof TickerRow = sortKeyToField(sort);
+    const order = dir === 'asc' ? 1 : -1;
 
     out = [...out].sort((a, b) => {
-      const av = a[key] // number | string
-      const bv = b[key] // number | string
-      if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * order
-      return String(av).localeCompare(String(bv)) * order
-    })
-    return out
+      const av = a[key]; // number | string
+      const bv = b[key]; // number | string
+      if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * order;
+      return String(av).localeCompare(String(bv)) * order;
+    });
+
+    return out;
   }, [data, watched])
 
   // --- UI ---
-  if (isLoading) return <Spinner animation="border" />
-  if (error) return <p>Failed to load.</p>
+  if (isLoading) return <Spinner animation="border" />;
+  if (error) return <p>Failed to load.</p>;
 
   return (
     <div>
@@ -145,7 +162,7 @@ export default function ScreenerPage() {
             </Form.Select>
           </Col>
           <Col md="auto">
-            <Form.Label>Dir</Form.Label>
+            <Form.Label>Sort Direction</Form.Label>
             <div>
               <Button
                 variant={watched.dir === 'desc' ? 'primary' : 'secondary'}
@@ -163,7 +180,12 @@ export default function ScreenerPage() {
         </Row>
       </Form>
 
-      <ScreenerTable rows={filtered} />
+      <ScreenerTable
+        rows={filtered}
+        activeSort={watched.sort}
+        dir={watched.dir}
+        onSort={onSort}
+      />
     </div>
   )
 }

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -2,16 +2,36 @@ import { Table, Badge, Button } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 import type { TickerRow } from '../../../lib/types';
 import { useWatchlist } from '../../watchlists/useWatchlist';
+import { SortHeader } from './SortHeader';
 
-export default function ScreenerTable({ rows }: { rows: TickerRow[] }) {
+// sort types
+type SortDir = 'asc' | 'desc';
+type SortableColumn = keyof TickerRow | 'pctChange';
+
+type Props = {
+  rows: TickerRow[];
+  activeSort: SortableColumn;
+  dir: SortDir;
+  onSort: (col: SortableColumn) => void;
+};
+
+export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) {
 
   const { add, remove, has } = useWatchlist();
 
   return (
-    <Table striped bordered hover variant="dark" size="sm" responsive>
+    <Table className="table-sticky" striped bordered hover variant="dark" size="sm" responsive>
       <thead>
         <tr>
-          <th>Ticker</th>
+          <th>
+            <SortHeader
+              label="Ticker"
+              col="ticker"
+              activeSort={activeSort}
+              dir={dir}
+              onSort={onSort}
+            />
+          </th>
           <th>Price</th>
           <th>%</th>
           <th>SI% (Public)</th>
@@ -39,7 +59,7 @@ export default function ScreenerTable({ rows }: { rows: TickerRow[] }) {
               <td>{r.dtc.toFixed(1)}</td>
               <td>{r.rvol.toFixed(1)}</td>
               <td>{r.catalyst ? <Badge bg="warning" text="dark">Yes</Badge> : '—'}</td>
-              <td>
+              <td className="text-nowrap">
                 {tracked ? (
                   <Button size="sm" variant="outline-warning" onClick={() => remove(r.ticker)}>
                     Remove

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -42,7 +42,15 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
               onSort={onSort}
             />
           </th>
-          <th>SI% (Public)</th>
+          <th>
+            <SortHeader
+              label="SI% (Public)"
+              col="siPublic"
+              activeSort={activeSort}
+              dir={dir}
+              onSort={onSort}
+            />
+          </th>
           <th>SI% (Broad)</th>
           <th>DTC</th>
           <th>

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -4,10 +4,19 @@ import type { TickerRow } from '../../../lib/types';
 import { useWatchlist } from '../../watchlists/useWatchlist';
 import { SortHeader } from './SortHeader';
 
-// sort types
+/**
+ * Local sort types mirroring the page and SortHeader types.
+ * Keeping them here avoids importing feature-wide types just for this file.
+ */
 type SortDir = 'asc' | 'desc';
 type SortableColumn = keyof TickerRow | 'pctChange';
 
+/**
+ * Table props:
+ * - rows:     already filtered/sorted data for display
+ * - activeSort/dir: current sort state (drives header UI and aria-sort)
+ * - onSort:   invoked by SortHeader to update the sort state upstream
+ */
 type Props = {
   rows: TickerRow[];
   activeSort: SortableColumn;
@@ -15,62 +24,97 @@ type Props = {
   onSort: (col: SortableColumn) => void;
 };
 
+/**
+ * DRY config for sortable headers. Hoisted outside the component
+ * to avoid re-allocating the array on every render.
+ */
+const COLUMNS: ReadonlyArray<{ label: string; col: SortableColumn }> = [
+  { label: 'Ticker', col: 'ticker' },
+  { label: 'Price', col: 'price' },
+  { label: '% Change', col: 'pctChange' },
+  { label: 'SI% (Public)', col: 'siPublic' },
+  { label: 'SI% (Broad)', col: 'siBroad' },
+  { label: 'DTC', col: 'dtc' },
+  { label: 'RVOL', col: 'rvol' },
+];
+
 export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) {
-
   const { add, remove, has } = useWatchlist();
-
-  const columns: Array<{ label: string; col: SortableColumn }> = [
-    { label: 'Ticker', col: 'ticker' },
-    { label: 'Price', col: 'price' },
-    { label: '% Change', col: 'pctChange' },
-    { label: 'SI% (Public)', col: 'siPublic' },
-    { label: 'SI% (Broad)', col: 'siBroad' },
-    { label: 'DTC', col: 'dtc' },
-    { label: 'RVOL', col: 'rvol' },
-  ];
 
   return (
     <Table className="table-sticky" striped bordered hover variant="dark" size="sm" responsive>
       <thead>
         <tr>
-          {columns.map(({ label, col }) => (
+          {/* Sortable columns: render from config to keep markup consistent and maintainable.
+              aria-sort communicates the current sort state to assistive tech. */}
+          {COLUMNS.map(({ label, col }) => (
             <th
               key={col}
               aria-sort={activeSort === col ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+              data-sort-active={activeSort === col ? 'true' : 'false'}
             >
-              <SortHeader label={label} col={col} activeSort={activeSort} dir={dir} onSort={onSort} />
+              <SortHeader
+                label={label}
+                col={col}
+                activeSort={activeSort}
+                dir={dir}
+                onSort={onSort}
+              />
             </th>
           ))}
 
-          {/* Not sorting by Catalyst or Watch */}
+          {/* Non-sortable columns: Catalyst flag and Watchlist actions */}
           <th>Catalyst</th>
           <th>Watch</th>
         </tr>
       </thead>
       <tbody>
+         {/* Note: rows are assumed normalized and typed upstream.
+            Keep row rendering straightforward and side-effect free. */}
         {rows.map(r => {
-
           const tracked = has(r.ticker);
 
           return (
             <tr key={r.ticker}>
-              <td><Link to={`/ticker/${r.ticker}`}>{r.ticker}</Link></td>
+              <td>
+                {/* Link to detail page; keep the symbol as-is (already uppercased upstream). */}
+                <Link to={`/ticker/${r.ticker}`}>{r.ticker}</Link>
+              </td>
+
+              {/* Number cells: use toFixed for consistent decimals in the current UX.
+                  (If needed later, switch to Intl.NumberFormat for locale-aware formatting.) */}
               <td>{r.price.toFixed(2)}</td>
+
               <td className={r.pctChange >= 0 ? 'text-success' : 'text-danger'}>
                 {r.pctChange.toFixed(2)}
               </td>
+
               <td>{r.siPublic.toFixed(1)}</td>
               <td>{r.siBroad.toFixed(1)}</td>
               <td>{r.dtc.toFixed(1)}</td>
               <td>{r.rvol.toFixed(1)}</td>
+
+              {/* Catalyst: use a badge for quick scanning; fallback em dash when false. */}
               <td>{r.catalyst ? <Badge bg="warning" text="dark">Yes</Badge> : '—'}</td>
+
+              {/* Watchlist action: compact buttons; keep layout stable with text-nowrap. */}
               <td className="text-nowrap">
                 {tracked ? (
-                  <Button size="sm" variant="outline-warning" onClick={() => remove(r.ticker)}>
+                  <Button
+                    size="sm"
+                    variant="outline-warning"
+                    onClick={() => remove(r.ticker)}
+                    aria-label={`Remove ${r.ticker} from watchlist`}
+                  >
                     Remove
                   </Button>
                 ) : (
-                  <Button size="sm" variant="outline-info" onClick={() => add(r.ticker)}>
+                  <Button
+                    size="sm"
+                    variant="outline-info"
+                    onClick={() => add(r.ticker)}
+                    aria-label={`Add ${r.ticker} to watchlist`}
+                  >
                     Add
                   </Button>
                 )}

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -52,7 +52,15 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
             />
           </th>
           <th>SI% (Broad)</th>
-          <th>DTC</th>
+          <th>
+            <SortHeader
+              label="DTC"
+              col="dtc"
+              activeSort={activeSort}
+              dir={dir}
+              onSort={onSort}
+            />
+          </th>
           <th>
             <SortHeader
               label="RVOL"

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -33,11 +33,27 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
             />
           </th>
           <th>Price</th>
-          <th>%</th>
+          <th>
+            <SortHeader
+              label="% Change"
+              col="pctChange"
+              activeSort={activeSort}
+              dir={dir}
+              onSort={onSort}
+            />
+          </th>
           <th>SI% (Public)</th>
           <th>SI% (Broad)</th>
           <th>DTC</th>
-          <th>RVOL</th>
+          <th>
+            <SortHeader
+              label="RVOL"
+              col="rvol"
+              activeSort={activeSort}
+              dir={dir}
+              onSort={onSort}
+            />
+          </th>
           <th>Catalyst</th>
           <th>Watch</th>
         </tr>

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -19,73 +19,29 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
 
   const { add, remove, has } = useWatchlist();
 
+  const columns: Array<{ label: string; col: SortableColumn }> = [
+    { label: 'Ticker', col: 'ticker' },
+    { label: 'Price', col: 'price' },
+    { label: '% Change', col: 'pctChange' },
+    { label: 'SI% (Public)', col: 'siPublic' },
+    { label: 'SI% (Broad)', col: 'siBroad' },
+    { label: 'DTC', col: 'dtc' },
+    { label: 'RVOL', col: 'rvol' },
+  ];
+
   return (
     <Table className="table-sticky" striped bordered hover variant="dark" size="sm" responsive>
       <thead>
         <tr>
-          <th aria-sort={activeSort === 'ticker' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-            <SortHeader
-              label="Ticker"
-              col="ticker"
-              activeSort={activeSort}
-              dir={dir}
-              onSort={onSort}
-            />
-          </th>
-          <th aria-sort={activeSort === 'price' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-            <SortHeader
-              label="Price"
-              col="price"
-              activeSort={activeSort}
-              dir={dir}
-              onSort={onSort}
-            />
-          </th>
-          <th aria-sort={activeSort === 'pctChange' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-            <SortHeader
-              label="% Change"
-              col="pctChange"
-              activeSort={activeSort}
-              dir={dir}
-              onSort={onSort}
-            />
-          </th>
-          <th aria-sort={activeSort === 'siPublic' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-            <SortHeader
-              label="SI% (Public)"
-              col="siPublic"
-              activeSort={activeSort}
-              dir={dir}
-              onSort={onSort}
-            />
-          </th>
-          <th aria-sort={activeSort === 'siBroad' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-            <SortHeader
-              label="SI% (Broad)"
-              col="siBroad"
-              activeSort={activeSort}
-              dir={dir}
-              onSort={onSort}
-            />
-          </th>
-          <th aria-sort={activeSort === 'dtc' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-            <SortHeader
-              label="DTC"
-              col="dtc"
-              activeSort={activeSort}
-              dir={dir}
-              onSort={onSort}
-            />
-          </th>
-          <th aria-sort={activeSort === 'rvol' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
-            <SortHeader
-              label="RVOL"
-              col="rvol"
-              activeSort={activeSort}
-              dir={dir}
-              onSort={onSort}
-            />
-          </th>
+          {columns.map(({ label, col }) => (
+            <th
+              key={col}
+              aria-sort={activeSort === col ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}
+            >
+              <SortHeader label={label} col={col} activeSort={activeSort} dir={dir} onSort={onSort} />
+            </th>
+          ))}
+
           {/* Not sorting by Catalyst or Watch */}
           <th>Catalyst</th>
           <th>Watch</th>

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -23,7 +23,7 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
     <Table className="table-sticky" striped bordered hover variant="dark" size="sm" responsive>
       <thead>
         <tr>
-          <th>
+          <th aria-sort={activeSort === 'ticker' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
             <SortHeader
               label="Ticker"
               col="ticker"
@@ -32,8 +32,16 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
               onSort={onSort}
             />
           </th>
-          <th>Price</th>
-          <th>
+          <th aria-sort={activeSort === 'price' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+            <SortHeader
+              label="Price"
+              col="price"
+              activeSort={activeSort}
+              dir={dir}
+              onSort={onSort}
+            />
+          </th>
+          <th aria-sort={activeSort === 'pctChange' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
             <SortHeader
               label="% Change"
               col="pctChange"
@@ -42,7 +50,7 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
               onSort={onSort}
             />
           </th>
-          <th>
+          <th aria-sort={activeSort === 'siPublic' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
             <SortHeader
               label="SI% (Public)"
               col="siPublic"
@@ -51,8 +59,16 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
               onSort={onSort}
             />
           </th>
-          <th>SI% (Broad)</th>
-          <th>
+          <th aria-sort={activeSort === 'siBroad' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
+            <SortHeader
+              label="SI% (Broad)"
+              col="siBroad"
+              activeSort={activeSort}
+              dir={dir}
+              onSort={onSort}
+            />
+          </th>
+          <th aria-sort={activeSort === 'dtc' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
             <SortHeader
               label="DTC"
               col="dtc"
@@ -61,7 +77,7 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
               onSort={onSort}
             />
           </th>
-          <th>
+          <th aria-sort={activeSort === 'rvol' ? (dir === 'asc' ? 'ascending' : 'descending') : 'none'}>
             <SortHeader
               label="RVOL"
               col="rvol"
@@ -70,6 +86,7 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
               onSort={onSort}
             />
           </th>
+          {/* Not sorting by Catalyst or Watch */}
           <th>Catalyst</th>
           <th>Watch</th>
         </tr>

--- a/src/features/tickers/components/SortHeader.tsx
+++ b/src/features/tickers/components/SortHeader.tsx
@@ -1,0 +1,30 @@
+import { Button } from 'react-bootstrap';
+import type { TickerRow } from '../../../lib/types';
+
+export type SortDir = 'asc' | 'desc';
+export type sortableColumn = keyof TickerRow | 'pctChange';
+
+type Props = {
+  label: string;
+  col: sortableColumn;
+  activeSort: sortableColumn;
+  dir: SortDir;
+  onSort: (col: sortableColumn) => void;
+};
+
+export function SortHeader({ label, col, activeSort, dir, onSort }: Props) {
+  const isActive = activeSort === col; // isActive = true if activeSort and col are identical
+  const caret = isActive ? (dir === 'asc' ? '▲' : '▼') : '▵';
+
+  return (
+    <Button
+      variant="link"
+      size="sm"
+      className="p-0 text-decoration-none text-light"
+      onClick={() => onSort(col)}
+      aria-label={`Sort by ${label}${isActive ? `, ${dir}` : ''}`}
+    >
+      {label} <span aria-hidden="true">{caret}</span>
+    </Button>
+  );
+}

--- a/src/features/tickers/components/SortHeader.tsx
+++ b/src/features/tickers/components/SortHeader.tsx
@@ -14,17 +14,22 @@ type Props = {
 
 export function SortHeader({ label, col, activeSort, dir, onSort }: Props) {
   const isActive = activeSort === col; // isActive = true if activeSort and col are identical
-  const caret = isActive ? (dir === 'asc' ? '▲' : '▼') : '▵';
+  const caret = dir === 'asc' ? '▲' : '▼';
 
   return (
     <Button
       variant="link"
       size="sm"
-      className="p-0 text-decoration-none text-light"
+      className="p-0 text-decoration-none text-light sort-header-btn"
       onClick={() => onSort(col)}
-      aria-label={`Sort by ${label}${isActive ? `, ${dir}` : ''}`}
+      title={isActive ? `Sorted by ${label}  (${dir})` : `Sort by ${label}`}
+      aria-label={
+        isActive ? `Sort by ${label}, currently ${dir}. Toggle direction.` : `Sort by ${label}`
+      }
     >
-      {label} <span aria-hidden="true">{caret}</span>
+      {label}{' '}
+      {/* show caret only on active column */}
+      {isActive ? <span aria-hidden="true">{caret}</span> : null}
     </Button>
   );
 }

--- a/src/features/tickers/components/SortHeader.tsx
+++ b/src/features/tickers/components/SortHeader.tsx
@@ -20,16 +20,19 @@ export function SortHeader({ label, col, activeSort, dir, onSort }: Props) {
     <Button
       variant="link"
       size="sm"
-      className="p-0 text-decoration-none text-light sort-header-btn"
+      className="sort-header-btn w-100 text-start"
       onClick={() => onSort(col)}
       title={isActive ? `Sorted by ${label}  (${dir})` : `Sort by ${label}`}
       aria-label={
         isActive ? `Sort by ${label}, currently ${dir}. Toggle direction.` : `Sort by ${label}`
       }
+      data-active={isActive ? 'true' : 'false'}
     >
-      {label}{' '}
-      {/* show caret only on active column */}
-      {isActive ? <span aria-hidden="true">{caret}</span> : null}
+      <span className="sort-header-inner">
+        <span className="sort-header-label">{label}</span>
+        {/* caret placeholder is ALWAYS rendered to reserve space */}
+        <span className="sort-caret" aria-hidden="true">{caret}</span>
+      </span>
     </Button>
   );
 }

--- a/src/features/tickers/screenerSchema.ts
+++ b/src/features/tickers/screenerSchema.ts
@@ -1,10 +1,23 @@
-import { z } from 'zod'
+import { z } from 'zod';
 
-export const sortKeys = ['ticker', 'siPublic', 'dtc', 'rvol', 'pctChange'] as const
-export type SortKey = typeof sortKeys[number]
+/**
+ * Supported keys to sort the list of stocks by a given metric.
+ */
+export const sortKeys = [
+  'ticker',
+  'siPublic',
+  'siBroad',
+  'dtc',
+  'rvol',
+  'pctChange',
+  'price',
+] as const;
 
-export const dirKeys = ['asc', 'desc'] as const
-export type Dir = typeof dirKeys[number]
+export type SortKey = typeof sortKeys[number];
+
+/** Sort direction */
+export const dirKeys = ['asc', 'desc'] as const;
+export type Dir = typeof dirKeys[number];
 
 /**
  * Input schema (coerces & supplies defaults from URL/query).
@@ -16,9 +29,9 @@ export const ScreenerInputSchema = z.object({
   dtcMin: z.coerce.number().min(0).max(10).default(0),
   rvolMin: z.coerce.number().min(0).max(10).default(0),
   catalyst: z.coerce.boolean().default(false),
-  sort: z.enum(sortKeys).default('rvol'),
-  dir: z.enum(dirKeys).default('desc'),
-})
+  sort: z.enum(sortKeys).default('ticker'),
+  dir: z.enum(dirKeys).default('asc'),
+});
 
 /**
  * Form schema (all fields required & correctly typed for RHF).
@@ -32,6 +45,6 @@ export const ScreenerFormSchema = z.object({
   catalyst: z.boolean(),
   sort: z.enum(sortKeys),
   dir: z.enum(dirKeys),
-})
+});
 
-export type ScreenerValues = z.infer<typeof ScreenerFormSchema>
+export type ScreenerValues = z.infer<typeof ScreenerFormSchema>;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,25 +1,30 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import { RouterProvider } from 'react-router-dom'
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { router } from './app/router'
-import 'bootstrap/dist/css/bootstrap.min.css'   // <-- Bootstrap CSS
-import './styles/globals.css'                    // (create file in step 3)
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { RouterProvider } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { router } from './app/router';
+import 'bootstrap/dist/css/bootstrap.min.css';
+import './styles/globals.css';
 
-const qc = new QueryClient()
+const qc = new QueryClient();
 
-async function enableMocks() {
+async function prepare() {
   if (import.meta.env.DEV) {
     const { worker } = await import('./mocks/browser')
-    await worker.start()
-  }
-}
-enableMocks()
+    // Ensure that MSW starts BEFORE rendering - otherwise mock data in dev env will have issues loading
+    await worker.start({
+      serviceWorker: { url: '/mockServiceWorker.js' },
+      onUnhandledRequest: 'bypass',
+    });
+  };
+};
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <QueryClientProvider client={qc}>
-      <RouterProvider router={router} />
-    </QueryClientProvider>
-  </React.StrictMode>
-)
+prepare().then(() => {
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <QueryClientProvider client={qc}>
+        <RouterProvider router={router} />
+      </QueryClientProvider>
+    </React.StrictMode>
+  );
+});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,3 +1,11 @@
 html, body, #root { height: 100%; }
 body { background: #0b0e14; color: #e6e6e6; }
 a { text-decoration: none; }
+
+/* Sticky Header */
+.table-sticky thead th {
+  position: sticky;
+  top: 0;
+  z-index: 2;
+  background: #121212;
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,26 +2,55 @@ html, body, #root { height: 100%; }
 body { background: #0b0e14; color: #e6e6e6; }
 a { text-decoration: none; }
 
-/* Sticky Header */
-.table-sticky thead th {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background: #121212;
+/* Make header button fill the cell and feel clickable */
+.table-sticky thead th .sort-header-btn {
+  display: block;
+  width: 100%;
+  padding: 0.25rem 0;      /* stable click target */
+  color: inherit;
+  text-decoration: none;
+  cursor: pointer;
 }
 
-/* Sort header button - subtle underline on hover, clear focus ring */
-.sort-header-btn:hover {
-  text-decoration: underline;
+/* Align label + caret, prevent width shift */
+.table-sticky thead th .sort-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;  /* label left, caret right */
+  gap: 0.25rem;
 }
-.sort-header-btn:focus-visible {
+
+/* Caret: reserve space even when "inactive" */
+.table-sticky thead th .sort-caret {
+  display: inline-block;
+  width: 1ch;              /* reserve width of one character */
+  text-align: right;
+  opacity: 0;              /* invisible by default */
+  transition: opacity 120ms ease;
+}
+
+/* Hover: subtle background for full header cell */
+.table-sticky thead th .sort-header-btn:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+/* Focus ring for keyboard users */
+.table-sticky thead th .sort-header-btn:focus-visible {
   outline: 2px solid rgba(255, 255, 255, 0.6);
   outline-offset: 2px;
   border-radius: 4px;
 }
 
-/* Active header will be slightly brighter to make it a bit more obvious */
-.sort-header-btn[data-active="true"] {
-  color: #fff;
-  font-weight: 700;
+/* ACTIVE COLUMN:
+   - Don't change font-size/weight (prevents width reflow)
+   - Use subtle background + bottom border + show caret */
+.table-sticky thead th[data-sort-active="true"] .sort-header-btn {
+  background: rgba(255, 255, 255, 0.04);
+  border-bottom: 2px solid rgba(255, 255, 255, 0.35);
+  border-radius: 4px 4px 0 0;
+}
+.table-sticky thead th[data-sort-active="true"] .sort-caret {
+  opacity: 0.9;            /* visible only when active */
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -9,3 +9,19 @@ a { text-decoration: none; }
   z-index: 2;
   background: #121212;
 }
+
+/* Sort header button - subtle underline on hover, clear focus ring */
+.sort-header-btn:hover {
+  text-decoration: underline;
+}
+.sort-header-btn:focus-visible {
+  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+/* Active header will be slightly brighter to make it a bit more obvious */
+.sort-header-btn[data-active="true"] {
+  color: #fff;
+  font-weight: 700;
+}


### PR DESCRIPTION
**Summary**  
Implements improvements from Issue #4 to make the Screener table easier to read and navigate.

**Changes**  
- Made the table header sticky so it stays visible while scrolling.  
- Added sort indicators (▲/▼) that update based on the active column and direction.  
- Highlighted the active sort column for better visibility.  
- Preserved keyboard focus styles so tabbing shows a clear focus ring.  
- Made the entire header cell clickable, not just the text, to improve usability.  
- Added `aria-sort` attributes for accessibility.

**Why**  
These updates improve both readability and accessibility. Users can always see the header, understand the current sort order at a glance, and navigate the table more easily with keyboard or screen readers.

**Acceptance Criteria**  
- [x] Header remains visible while scrolling  
- [x] Sort indicators reflect active column and direction  
- [x] Focus styles remain visible when navigating with keyboard  

**Linked Issue**  
Closes #4 