### PR TITLE
chore(build): ignore TypeScript build cache; disable incremental compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ Thumbs.db
 
 # TypeScript build cache
 *.tsbuildinfo
+
+# TypeScript build cache
+*.tsbuildinfo

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 *.njsproj
 *.sln
 *.sw?
+
+# TypeScript build cache
+*.tsbuildinfo

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -13,6 +13,7 @@
     "verbatimModuleSyntax": true,
     "moduleDetection": "force",
     "noEmit": true,
+    "incremental": false,
     "jsx": "react-jsx",
 
     /* Linting */


### PR DESCRIPTION
Summary:
Ignore TypeScript .tsbuildinfo files and explicitly disable incremental compilation. Prevents accidental build cache artifacts from being checked in and keeps the repo clean.

Changes:
- .gitignore: add *.tsbuildinfo
- tsconfig.app.json: set incremental=false (noEmit already enabled)

Notes:
Vite handles TypeScript transpilation. We run tsc only for type-checking (noEmit), so build cache files are unnecessary.

Risk:
None. No runtime behavior changes.

Merge strategy:
Squash and merge.
