### PR TITLE
feat(ui): polish spacing/typography; align sortable headers; compact density + dark tweaks (closes #13)

### DIFF
--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -42,7 +42,14 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
   const { add, remove, has } = useWatchlist();
 
   return (
-    <Table className="table-sticky" striped bordered hover variant="dark" size="sm" responsive>
+    <Table
+      className="table-sticky ss-compact ss-lines-ss-hover"
+      striped
+      hover
+      variant="dark"
+      size="sm"
+      responsive
+    >
       <thead>
         <tr>
           {/* Sortable columns: render from config to keep markup consistent and maintainable.

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,56 +1,106 @@
+/* SqueezeScope globals — Bootstrap-first, minimal overrides */
+
 html, body, #root { height: 100%; }
 body { background: #0b0e14; color: #e6e6e6; }
 a { text-decoration: none; }
 
-/* Make header button fill the cell and feel clickable */
+:root {
+  --ss-font-sans: system-ui, -apple-system, Segoe UI, Roboto, Inter, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
+  --ss-space-1: .25rem;
+  --ss-space-2: .5rem;
+  --ss-space-3: .75rem;
+  --ss-space-4: 1rem;
+  --ss-space-5: 1.5rem;
+  --ss-radius: .75rem;
+  --ss-focus: rgba(13,110,253,.45);
+}
+
+html, body { font-family: var(--ss-font-sans); }
+
+/* Sortable table header */
+.table-sticky thead th {
+  position: relative;
+  vertical-align: middle;
+  font-weight: 600;
+  line-height: 1.25;
+}
+
 .table-sticky thead th .sort-header-btn {
+  all: unset;
   display: block;
   width: 100%;
-  padding: 0.25rem 0;      /* stable click target */
-  color: inherit;
-  text-decoration: none;
   cursor: pointer;
+  font: inherit;
+  color: inherit;
+  line-height: 1.25;
 }
 
-/* Align label + caret, prevent width shift */
-.table-sticky thead th .sort-header-inner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;  /* label left, caret right */
-  gap: 0.25rem;
-}
-
-/* Caret: reserve space even when "inactive" */
-.table-sticky thead th .sort-caret {
-  display: inline-block;
-  width: 1ch;              /* reserve width of one character */
-  text-align: right;
-  opacity: 0;              /* invisible by default */
-  transition: opacity 120ms ease;
-}
-
-/* Hover: subtle background for full header cell */
 .table-sticky thead th .sort-header-btn:hover {
-  background: rgba(255, 255, 255, 0.06);
+  background: rgba(255,255,255,.06);
   border-radius: 4px;
-  text-decoration: none;
 }
 
-/* Focus ring for keyboard users */
 .table-sticky thead th .sort-header-btn:focus-visible {
-  outline: 2px solid rgba(255, 255, 255, 0.6);
+  outline: 2px solid rgba(255,255,255,.6);
   outline-offset: 2px;
   border-radius: 4px;
 }
 
-/* ACTIVE COLUMN:
-   - Don't change font-size/weight (prevents width reflow)
-   - Use subtle background + bottom border + show caret */
+.table-sticky thead th .sort-header-inner {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: var(--ss-space-1);
+}
+
+.table-sticky thead th .sort-caret {
+  position: absolute;
+  right: var(--ss-space-3);
+  top: 50%;
+  transform: translateY(-50%);
+  width: 1ch;
+  text-align: right;
+  opacity: 0;
+  transition: opacity 120ms ease;
+  pointer-events: none;
+}
+
 .table-sticky thead th[data-sort-active="true"] .sort-header-btn {
-  background: rgba(255, 255, 255, 0.04);
-  border-bottom: 2px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255,255,255,.04);
+  border-bottom: 2px solid rgba(255,255,255,.35);
   border-radius: 4px 4px 0 0;
 }
-.table-sticky thead th[data-sort-active="true"] .sort-caret {
-  opacity: 0.9;            /* visible only when active */
+.table-sticky thead th[data-sort-active="true"] .sort-caret { opacity: .9; }
+
+/* Optional indicator element support */
+.table thead th .sort-indicator { opacity: .6; margin-left: .25rem; }
+.table thead th[aria-sort="ascending"] .sort-indicator,
+.table thead th[aria-sort="descending"] .sort-indicator { opacity: 1; }
+
+/* Table density/lines/hover (opt-in) */
+.table.ss-compact thead > tr > th,
+.table.ss-compact tbody > tr > td {
+  padding: var(--ss-space-2) var(--ss-space-3);
+}
+
+.table.ss-lines tbody > tr:not(:last-child) {
+  border-bottom: 1px solid rgba(0,0,0,.06);
+}
+.table.ss-hover tbody tr:hover {
+  background: rgba(0,0,0,.03);
+}
+
+/* Dark theme tweaks */
+.table-dark.ss-lines tbody > tr:not(:last-child) {
+  border-bottom: 1px solid rgba(255,255,255,.08);
+}
+.table-dark.ss-hover tbody tr:hover {
+  background: rgba(255,255,255,.06);
+}
+
+/* Global focus ring */
+:where(a, button, [role="button"], .btn):focus-visible {
+  outline: 3px solid var(--ss-focus);
+  outline-offset: 2px;
+  border-radius: var(--ss-radius);
 }


### PR DESCRIPTION
## Summary
Polish the Screener table and global styles for a tighter, more professional UI. This aligns sortable header labels with their data columns, introduces compact density and subtle row dividers/hover states (light and dark), and standardizes an accessible focus ring.

## Changes
- Add design tokens (spacing, radius, focus color) and sans font stack in `globals.css`
- Normalize sortable header typography and alignment; remove UA/Bootstrap button offsets
- Absolutely position sort caret so it never shifts the label
- Opt-in helpers: `ss-compact`, `ss-lines`, `ss-hover` for table density/lines/hover
- Dark theme tuning for row dividers and hover backgrounds
- Apply helpers to Screener table; drop `bordered` to avoid double rules

## Accessibility
- Consistent `:focus-visible` ring on interactive elements
- Header labels left-aligned with cell text for better scanability

## Testing
- Dev: visually verify header labels align with data columns in all sortable and non-sortable headers
- Toggle sort states; caret appears without shifting label
- Check dark mode table: subtle row dividers and hover states
- Lighthouse (A11y) should not regress

## Risk
Low. Changes are additive and opt-in (`ss-*` classes); Bootstrap defaults remain intact.

## Related
Closes #13 