### PR TITLE
feat(ui): watchlist uses compact table + aligned utility columns

### DIFF
--- a/src/features/watchlists/WatchlistPage.tsx
+++ b/src/features/watchlists/WatchlistPage.tsx
@@ -1,25 +1,109 @@
-import { useWatchlist } from "./useWatchlist";
-import { ListGroup, Button } from "react-bootstrap";
-import { Link } from "react-router-dom";
+import * as React from 'react';
+import { Link } from 'react-router-dom';
+import { Table, Button, Badge, Spinner, Alert } from 'react-bootstrap';
+import { useQuery } from '@tanstack/react-query';
+import { useWatchlist } from './useWatchlist';
+import { api } from '../../lib/api';
+import type { TickerRow } from '../../lib/types';
 
 export default function WatchlistPage() {
   const { list, remove } = useWatchlist();
+  const tickers = React.useMemo(() => new Set<string>(Array.isArray(list) ? list : []), [list]);
 
-  if (list.length === 0) {
-    return <p>Your watchlist appears to be empty. Go to the <Link to="/screener">Screener</Link> to add a stock ticker to your watchlist.</p>
+  const { data, isLoading, error } = useQuery<TickerRow[] | { rows: TickerRow[] }>({
+    queryKey: ['tickers'],
+    queryFn: async () => (await api.get<TickerRow[]>('/tickers')).data,
+  });
+
+  const allRows: TickerRow[] = Array.isArray(data) ? data : Array.isArray(data?.rows) ? data.rows : [];
+  const rows = allRows.filter(r => tickers.has(r.ticker));
+
+  if (isLoading) {
+    return (
+      <div className="d-flex justify-content-center py-5">
+        <Spinner animation="border" role="status" aria-label="Loading watchlist…" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <Alert variant="danger" className="my-3">
+        Failed to load data. Try reloading.
+      </Alert>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <section className="container py-4" aria-labelledby="watchlist-heading">
+        <h2 id="watchlist-heading" className="mb-3">Watchlist</h2>
+        <Alert variant="secondary" className="d-flex justify-content-between align-items-center">
+          <span>Your watchlist is empty.</span>
+          <Link to="/screener" className="btn btn-primary btn-sm">Go to Screener</Link>
+        </Alert>
+      </section>
+    );
   }
 
   return (
-    <div>
-      <h2 className="mb-3">Watchlist</h2>
-      <ListGroup variant="flush">
-        {list.map(t => (
-          <ListGroup.Item key={t} className="d-flex align-items-center justify-content-between">
-            <Link to={`/ticker/${t}`}>{t}</Link>
-            <Button size="sm" variant="outline-danger" onClick={() => remove(t)}>Remove</Button>
-          </ListGroup.Item>
-        ))}
-      </ListGroup>
-    </div>
-  )
-}
+    <section className="container py-4" aria-labelledby="watchlist-heading">
+      <div className="d-flex justify-content-between align-items-center mb-3">
+        <h2 id="watchlist-heading" className="mb-0">Watchlist</h2>
+        <Badge bg="secondary" pill aria-label={`${rows.length} saved tickers`}>{rows.length}</Badge>
+      </div>
+
+      <Table
+        className="table-sticky ss-compact ss-lines ss-hover"
+        variant="dark"
+        size="sm"
+        responsive
+        striped
+      >
+        <thead>
+          <tr>
+            <th scope="col" className="text-start">Ticker</th>
+            <th scope="col" className="text-start">Price</th>
+            <th scope="col" className="text-start">% Change</th>
+            <th scope="col" className="text-start">SI% Public</th>
+            <th scope="col" className="text-start">RVOL</th>
+            <th scope="col" className="text-start col-fit">Catalyst</th>
+            <th scope="col" className="text-start col-fit">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map(r => (
+            <tr key={r.ticker}>
+              <td>
+                <Link to={`/ticker/${r.ticker}`} className="fw-semibold ss-ticker-link text-start">
+                  {r.ticker}
+                </Link>
+              </td>
+              <td className="text-start">{r.price?.toFixed?.(2) ?? '—'}</td>
+              <td className={`text-start ${Number(r.pctChange) >= 0 ? 'text-success' : 'text-danger'}`}>
+                {typeof r.pctChange === 'number' ? r.pctChange.toFixed(2) : '—'}
+              </td>
+              <td className="text-start">{r.siPublic ?? '—'}</td>
+              <td className="text-start">{r.rvol ?? '—'}</td>
+
+              <td className="text-start col-fit">
+                {r.catalyst ? <Badge bg="info" className="text-dark">Catalyst</Badge> : '—'}
+              </td>
+
+              <td className="text-start col-fit">
+                <Button
+                  variant="outline-danger"
+                  size="sm"
+                  onClick={() => remove(r.ticker)}
+                  aria-label={`Remove ${r.ticker} from watchlist`}
+                >
+                  Remove
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </section>
+  );
+};

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -119,3 +119,31 @@ html, body { font-family: var(--ss-font-sans); }
   outline-offset: 2px;
   border-radius: var(--ss-radius);
 }
+
+
+/* Watchlist */
+.ss-card {
+  background: rgba(255,255,255,.03);
+  border: 1px solid rgba(255,255,255,.08);
+  border-radius: var(--ss-radius);
+  /* box-shadow: 0 1px 2px rgba(0,0,0,.25); */
+}
+
+.ss-ticker-link {
+  text-decoration: none;
+}
+.ss-ticker-link:hover,
+.ss-ticker-link:focus {
+  text-decoration: underline;
+}
+
+/* blend list group rows with dark canvas */
+.list-group-item.bg-transparent {
+  background-color: transparent;
+  border-color: rgba(255,255,255,.08);
+}
+
+.table .col-fit {
+  width: 1%;
+  white-space: nowrap;
+}


### PR DESCRIPTION
## Summary
Switch Watchlist to a compact dark table for visual parity with Screener. Align utility columns (Catalyst, Actions) and normalize header/cell alignment.

## Changes
- Replace list-style Watchlist with a compact table (dark variant)
- Show key stats (price, % change, SI% Public, RVOL) for saved tickers
- Align Catalyst and Actions columns for clarity
- Keep empty state with CTA to Screener

## Risk
Low; uses existing table styles and APIs.

Closes #16 