### PR TITLE
feat(ticker): functional detail page via MSW detail handler + hero strip

### DIFF
--- a/src/features/tickers/TickerDetailPage.tsx
+++ b/src/features/tickers/TickerDetailPage.tsx
@@ -1,13 +1,14 @@
-import { useParams } from 'react-router-dom'
-import { useQuery } from '@tanstack/react-query'
-import { api } from '../../lib/api'
-import type { TickerMetrics } from '../../lib/types'
-import { Card, Row, Col, Spinner, Alert } from 'react-bootstrap'
-import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts'
+import { useParams } from 'react-router-dom';
+import { useQuery } from '@tanstack/react-query';
+import { api } from '../../lib/api';
+import type { TickerMetrics } from '../../lib/types';
+import { Card, Row, Col, Spinner, Alert, Badge, Button, Stack } from 'react-bootstrap';
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+import { useWatchlist } from '../watchlists/useWatchlist';
 
 function hasMetrics(x: unknown): x is TickerMetrics {
-  if (!x || typeof x !== 'object') return false
-  const m = x as Record<string, unknown>
+  if (!x || typeof x !== 'object') return false;
+  const m = x as Record<string, unknown>;
   return (
     typeof m.ticker === 'string' &&
     typeof m.siPublic === 'number' &&
@@ -16,33 +17,73 @@ function hasMetrics(x: unknown): x is TickerMetrics {
     typeof m.rvol30d === 'number' &&
     typeof m.squeezeScore === 'number' &&
     Array.isArray(m.series)
-  )
-}
+  );
+};
 
 export default function TickerDetailPage() {
-  const { symbol = '' } = useParams()
+  const { symbol = '' } = useParams();
+
+  // Hooks must run unconditionally on every render
+  const { list, add, remove } = useWatchlist();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['ticker', symbol],
     queryFn: async () => {
-      const res = await api.get<TickerMetrics>(`/tickers/${symbol}`)
-      return res.data
+      const res = await api.get<TickerMetrics>(`/tickers/${symbol}`);
+      return res.data;
     },
     enabled: Boolean(symbol),
     retry: false,
-  })
+  });
 
-  if (!symbol) return <Alert variant="warning">No symbol provided.</Alert>
-  if (isLoading) return <Spinner animation="border" />
+  if (!symbol) return <Alert variant="warning">No symbol provided.</Alert>;
+  if (isLoading) return <Spinner animation="border" role="status" aria-label="Loading…" />;
   if (error || !hasMetrics(data)) {
-    return <Alert variant="secondary">No data found for <strong>{symbol}</strong>.</Alert>
-  }
+    return <Alert variant="secondary">No data found for <strong>{symbol}</strong>.</Alert>;
+  };
 
-  const m = data
+  const m = data;
+
+  // Derive latest price from the series if present
+  const lastPrice =
+    Array.isArray(m.series) && m.series.length > 0 && typeof m.series[m.series.length - 1]?.price === 'number'
+      ? (m.series[m.series.length - 1].price as number)
+      : undefined;
+
+  const saved = Array.isArray(list) ? list.includes(m.ticker) : false;
+  const toggleWatch = () => (saved ? remove(m.ticker) : add(m.ticker));
 
   return (
-    <div>
-      <h2 className="mb-3">{m.ticker}</h2>
+    <section className="container py-4" aria-labelledby="ticker-heading">
+      {/* Hero strip: ticker + key facts + watch toggle */}
+      <div className="d-flex flex-wrap justify-content-between align-items-center mb-3">
+        <Stack direction="horizontal" gap={3} className="flex-wrap">
+          <h2 id="ticker-heading" className="mb-0">{m.ticker}</h2>
+
+          {typeof lastPrice === 'number' && (
+            <div className="text-secondary">${lastPrice.toFixed(2)}</div>
+          )}
+
+          <Badge bg="dark" className="border">
+            Squeeze Score: <span className="ms-1 fw-semibold">{m.squeezeScore}</span>
+          </Badge>
+
+          <Badge bg="secondary" title="30-day relative volume">
+            RVOL(30d): <span className="ms-1 fw-semibold">{m.rvol30d.toFixed(1)}</span>
+          </Badge>
+        </Stack>
+
+        <div className="d-flex gap-2 mt-2 mt-md-0">
+          <Button
+            size="sm"
+            variant={saved ? 'outline-danger' : 'primary'}
+            onClick={toggleWatch}
+            aria-label={saved ? `Remove ${m.ticker} from watchlist` : `Add ${m.ticker} to watchlist`}
+          >
+            {saved ? 'Remove from Watchlist' : 'Add to Watchlist'}
+          </Button>
+        </div>
+      </div>
 
       <Row className="g-3 mb-3">
         <Col md><Card body>SI% Public: {m.siPublic.toFixed(1)}</Card></Col>
@@ -64,6 +105,6 @@ export default function TickerDetailPage() {
           </ResponsiveContainer>
         </div>
       </Card>
-    </div>
-  )
+    </section>
+  );
 }

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,14 +1,67 @@
-import { http, HttpResponse } from 'msw'
-import tickers from './data/tickers.json'
-import metrics from './data/metrics.json'
+import { http, HttpResponse } from 'msw';
+import tickers from './data/tickers.json';
+import metrics from './data/metrics.json';
+
+type SeriesPoint = { t: string; price: number };
+type TickerMetrics = {
+  ticker: string;
+  siPublic: number;
+  siBroad: number;
+  dtc: number;
+  rvol30d: number;
+  squeezeScore: number;
+  series: SeriesPoint[];
+};
+
+const DELAY_MS = 0;
+
+const norm = (s: unknown) => String(s ?? '').trim().toUpperCase();
+
+function makeSeries(days = 60, startPrice = 100): SeriesPoint[] {
+  const out: SeriesPoint[] = [];
+  let price = startPrice;
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+    const delta = (Math.random() - 0.5) * 2; // ~[-1, 1]
+    price = Math.max(1, price + delta);
+    out.push({ t: d.toISOString().slice(0, 10), price: Number(price.toFixed(2)) });
+  }
+  return out;
+}
+
+function makeMetrics(ticker: string): TickerMetrics {
+  const base = 50 + Math.random() * 150; // 50–200
+  return {
+    ticker,
+    siPublic: Number((Math.random() * 20).toFixed(1)),
+    siBroad: Number((Math.random() * 30).toFixed(1)),
+    dtc: Number((Math.random() * 5).toFixed(1)),
+    rvol30d: Number((0.8 + Math.random() * 2.4).toFixed(1)),
+    squeezeScore: Math.floor(Math.random() * 100),
+    series: makeSeries(60, base),
+  };
+}
+
+function findOrCreateMetrics(symbol: string): TickerMetrics {
+  const target = norm(symbol);
+  const hit = (metrics as TickerMetrics[]).find(m => norm(m.ticker) === target);
+  return hit ?? makeMetrics(target);
+}
 
 export const handlers = [
-  http.get('/api/tickers', () => HttpResponse.json(tickers)),
-  http.get('/api/tickers/:symbol', ({ params }) => {
-    const m = metrics.find(x => x.ticker === params.symbol)
-    if (!m) {
-      return HttpResponse.json({ message: 'Not found' }, { status: 404 })
-    }
-    return HttpResponse.json(m)
+  http.get('/api/tickers', async () => {
+    if (DELAY_MS) await new Promise(r => setTimeout(r, DELAY_MS));
+    return HttpResponse.json(tickers, { status: 200 });
   }),
-]
+
+  http.get('/api/tickers/:symbol', async ({ params }) => {
+    const symbol = norm(params.symbol);
+    if (!symbol) {
+      return HttpResponse.json({ message: 'Missing symbol' }, { status: 400 });
+    }
+    if (DELAY_MS) await new Promise(r => setTimeout(r, DELAY_MS));
+    const m = findOrCreateMetrics(symbol);
+    return HttpResponse.json(m, { status: 200 });
+  }),
+];


### PR DESCRIPTION
Make Ticker Detail actually render by mocking GET /api/tickers/:symbol.
Adds a compact hero (ticker, derived latest price, squeeze score, RVOL 30d) and keeps existing metrics grid + chart.

- MSW: case-insensitive detail handler with demo fallback
- Page: watchlist toggle, price derived from series
- No new CSS; Bootstrap utilities only

Risk: Low (dev-only mocks)
