### PR TITLE
fix(screener): correct table lines/hover classes

### DIFF
--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -42,7 +42,7 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
 
   return (
     <Table
-      className="table-sticky ss-compact ss-lines-ss-hover"
+      className="table-sticky ss-compact ss-lines ss-hover"
       striped
       hover
       variant="dark"


### PR DESCRIPTION
## Summary

Fix a typo in the Screener table’s className so both .ss-lines and .ss-hover utility classes apply.

## Details

Before: "table-sticky ss-compact ss-lines-ss-hover" (missing space between ss-lines and ss-hover)

After: "table-sticky ss-compact ss-lines ss-hover"

This restores the intended dense table style with visible row separators and hover feedback, matching the Watchlist table.

closes #22 