### PR TITLE
refactor(tickers,watchlist): centralize query type and key

### DIFF
--- a/src/features/tickers/ScreenerPage.tsx
+++ b/src/features/tickers/ScreenerPage.tsx
@@ -18,13 +18,18 @@ import {
 import { filterRows } from './filter';
 import { sortRows, type SortKey as SortKeyForSort } from './sort';
 import { valuesFromParams, useScreenerUrlSync } from './urlState';
-import { toTickerRows } from './query';
+import {
+  toTickerRows,
+  type TickerQueryData,
+  TICKERS_QUERY_KEY,
+} from './query';
+
 
 
 export default function ScreenerPage() {
   // data
-  const { data, isLoading, error } = useQuery<TickerRow[] | { rows: TickerRow[] }>({
-    queryKey: ['tickers'],
+  const { data, isLoading, error } = useQuery<TickerQueryData>({
+    queryKey: TICKERS_QUERY_KEY,
     queryFn: async () => (await api.get<TickerRow[]>('/tickers')).data,
   });
 

--- a/src/features/tickers/query.ts
+++ b/src/features/tickers/query.ts
@@ -2,6 +2,8 @@ import type { TickerRow } from '../../lib/types';
 
 export type TickerQueryData = TickerRow[] | { rows: TickerRow[] } | undefined;
 
+export const TICKERS_QUERY_KEY = ['tickers'] as const;
+
 export function toTickerRows(input: TickerQueryData): TickerRow[] {
   if (!input) return [];
   return Array.isArray(input) ? input : input.rows;

--- a/src/features/watchlists/WatchlistPage.tsx
+++ b/src/features/watchlists/WatchlistPage.tsx
@@ -5,17 +5,22 @@ import { useQuery } from '@tanstack/react-query';
 import { useWatchlist } from './useWatchlist';
 import { api } from '../../lib/api';
 import type { TickerRow } from '../../lib/types';
+import {
+  toTickerRows,
+  type TickerQueryData,
+  TICKERS_QUERY_KEY,
+} from '../tickers/query';
 
 export default function WatchlistPage() {
   const { list, remove } = useWatchlist();
   const tickers = React.useMemo(() => new Set<string>(Array.isArray(list) ? list : []), [list]);
 
-  const { data, isLoading, error } = useQuery<TickerRow[] | { rows: TickerRow[] }>({
-    queryKey: ['tickers'],
+  const { data, isLoading, error } = useQuery<TickerQueryData>({
+    queryKey: TICKERS_QUERY_KEY,
     queryFn: async () => (await api.get<TickerRow[]>('/tickers')).data,
   });
 
-  const allRows: TickerRow[] = Array.isArray(data) ? data : Array.isArray(data?.rows) ? data.rows : [];
+  const allRows: TickerRow[] = toTickerRows(data);
   const rows = allRows.filter(r => tickers.has(r.ticker));
 
   if (isLoading) {


### PR DESCRIPTION
### Summary

Centralize the tickers query typing and query key so the Screener and Watchlist share the same `TickerQueryData`, `TICKERS_QUERY_KEY`, and `toTickerRows` helper.

### Changes

- **`src/features/tickers/query.ts`**
  - Export `TickerQueryData` as the canonical tickers query data type.
  - Add and export `TICKERS_QUERY_KEY = ['tickers'] as const`.
  - Keep `toTickerRows` as the single place that adapts `TickerQueryData` to `TickerRow[]`.

- **`src/features/tickers/ScreenerPage.tsx`**
  - Update `useQuery` to use `TickerQueryData` instead of an inline union type.
  - Replace the inline `['tickers']` with `TICKERS_QUERY_KEY` for the tickers query.

- **`src/features/watchlists/WatchlistPage.tsx`**
  - Update `useQuery` to use `TickerQueryData`.
  - Replace the inline `['tickers']` with `TICKERS_QUERY_KEY`.
  - Replace custom `Array.isArray(...)` logic with `toTickerRows(data)` to normalize the query result.

### Rationale

- Reduces duplication in how we handle the tickers API shape (`TickerRow[]` vs `{ rows: TickerRow[] }`).
- Ensures Screener and Watchlist stay in sync on:
  - The query key (`['tickers']`)
  - The query data type (`TickerQueryData`)
  - The adaptation step (`toTickerRows`)
- Sets the stage for future work where the tickers data source can switch between static demo data and a backend API behind a single interface.

### Testing

- `npm run lint`
- `npm run test`
- `npm run build`

All pass locally.

Closes #24 