### PR TITLE
chore(ui): align number formatting in tables

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -6,7 +6,7 @@ import tseslint from 'typescript-eslint'
 import { globalIgnores } from 'eslint/config'
 
 export default tseslint.config([
-  globalIgnores(['dist']),
+  globalIgnores(['dist', 'public/mockServiceWorker.js']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -4,6 +4,13 @@ import type { TickerRow } from '../../../lib/types';
 import { useWatchlist } from '../../watchlists/useWatchlist';
 import { SortHeader } from './SortHeader';
 import type { SortKey } from '../screenerSchema';
+import {
+  formatPrice,
+  formatPercentChange,
+  formatPercent1,
+  formatOneDecimal,
+} from '../format';
+
 
 /**
  * Local sort types mirroring the page.
@@ -75,7 +82,7 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
         </tr>
       </thead>
       <tbody>
-         {/* Note: rows are assumed normalized and typed upstream.
+        {/* Note: rows are assumed normalized and typed upstream.
             Keep row rendering straightforward and side-effect free. */}
         {rows.map(r => {
           const tracked = has(r.ticker);
@@ -89,16 +96,17 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
 
               {/* Number cells: use toFixed for consistent decimals in the current UX.
                   (If needed later, switch to Intl.NumberFormat for locale-aware formatting.) */}
-              <td>{r.price.toFixed(2)}</td>
+              <td>{formatPrice(r.price)}</td>
 
               <td className={r.pctChange >= 0 ? 'text-success' : 'text-danger'}>
-                {r.pctChange.toFixed(2)}
+                {formatPercentChange(r.pctChange)}
               </td>
 
-              <td>{r.siPublic.toFixed(1)}</td>
-              <td>{r.siBroad.toFixed(1)}</td>
-              <td>{r.dtc.toFixed(1)}</td>
-              <td>{r.rvol.toFixed(1)}</td>
+              <td>{formatPercent1(r.siPublic)}</td>
+              <td>{formatPercent1(r.siBroad)}</td>
+              <td>{formatOneDecimal(r.dtc)}</td>
+              <td>{formatOneDecimal(r.rvol)}</td>
+
 
               {/* Catalyst: use a badge for quick scanning; fallback em dash when false. */}
               <td>{r.catalyst ? <Badge bg="warning" text="dark">Yes</Badge> : '—'}</td>

--- a/src/features/tickers/format.ts
+++ b/src/features/tickers/format.ts
@@ -1,0 +1,21 @@
+export function formatPrice(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return value.toFixed(2);
+}
+
+export function formatPercentChange(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+
+  const sign = value > 0 ? '+' : value < 0 ? '' : '';
+  return `${sign}${value.toFixed(2)}%`;
+}
+
+export function formatPercent1(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return `${value.toFixed(1)}%`;
+}
+
+export function formatOneDecimal(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return '—';
+  return value.toFixed(1);
+}

--- a/src/features/watchlists/WatchlistPage.tsx
+++ b/src/features/watchlists/WatchlistPage.tsx
@@ -5,11 +5,20 @@ import { useQuery } from '@tanstack/react-query';
 import { useWatchlist } from './useWatchlist';
 import { api } from '../../lib/api';
 import type { TickerRow } from '../../lib/types';
+
 import {
   toTickerRows,
   type TickerQueryData,
   TICKERS_QUERY_KEY,
 } from '../tickers/query';
+
+import {
+  formatPrice,
+  formatPercentChange,
+  formatPercent1,
+  formatOneDecimal,
+} from '../tickers/format';
+
 
 export default function WatchlistPage() {
   const { list, remove } = useWatchlist();
@@ -84,12 +93,19 @@ export default function WatchlistPage() {
                   {r.ticker}
                 </Link>
               </td>
-              <td className="text-start">{r.price?.toFixed?.(2) ?? '—'}</td>
-              <td className={`text-start ${Number(r.pctChange) >= 0 ? 'text-success' : 'text-danger'}`}>
-                {typeof r.pctChange === 'number' ? r.pctChange.toFixed(2) : '—'}
+              <td className="text-start">{formatPrice(r.price)}</td>
+
+              <td
+                className={`text-start ${Number(r.pctChange) >= 0 ? 'text-success' : 'text-danger'}`}
+              >
+                {formatPercentChange(
+                  typeof r.pctChange === 'number' ? r.pctChange : Number(r.pctChange)
+                )}
               </td>
-              <td className="text-start">{r.siPublic ?? '—'}</td>
-              <td className="text-start">{r.rvol ?? '—'}</td>
+
+              <td className="text-start">{formatPercent1(r.siPublic)}</td>
+              <td className="text-start">{formatOneDecimal(r.rvol)}</td>
+
 
               <td className="text-start col-fit">
                 {r.catalyst ? <Badge bg="info" className="text-dark">Catalyst</Badge> : '—'}


### PR DESCRIPTION
### Summary

Align numeric formatting between the Screener and Watchlist tables using shared helpers for price, percent change, short interest, DTC, and RVOL.

- Price: 2 decimals
- Percent change: sign + 2 decimals (e.g. `+3.21%`)
- Short interest: 1 decimal with `%`
- DTC and RVOL: 1 decimal

### Testing

- `npm run test`
- `npm run lint`
- `npm run build`

Closes #27 