### PR TITLE
chore(data): centralize tickers client

### DIFF
--- a/src/features/tickers/client.ts
+++ b/src/features/tickers/client.ts
@@ -1,0 +1,15 @@
+import { api } from '../../lib/api';
+import type { TickerRow, TickerMetrics } from '../../lib/types';
+import { toTickerRows, type TickerQueryData } from './query';
+
+// Centralized tickers fetcher so Screener, Watchlist, and Ticker Detail
+export async function fetchTickers(): Promise<TickerRow[]> {
+  const res = await api.get<TickerRow[] | { rows: TickerRow[] }>('/tickers');
+  const data = res.data as TickerQueryData;
+  return toTickerRows(data);
+}
+
+export async function fetchTickerMetrics(symbol: string): Promise<TickerMetrics> {
+  const res = await api.get<TickerMetrics>(`/tickers/${symbol}`);
+  return res.data;
+}

--- a/src/features/watchlists/WatchlistPage.tsx
+++ b/src/features/watchlists/WatchlistPage.tsx
@@ -3,15 +3,9 @@ import { Link } from 'react-router-dom';
 import { Table, Button, Badge, Spinner, Alert } from 'react-bootstrap';
 import { useQuery } from '@tanstack/react-query';
 import { useWatchlist } from './useWatchlist';
-import { api } from '../../lib/api';
 import type { TickerRow } from '../../lib/types';
-
-import {
-  toTickerRows,
-  type TickerQueryData,
-  TICKERS_QUERY_KEY,
-} from '../tickers/query';
-
+import { TICKERS_QUERY_KEY } from '../tickers/query';
+import { fetchTickers } from '../tickers/client';
 import {
   formatPrice,
   formatPercentChange,
@@ -20,17 +14,19 @@ import {
 } from '../tickers/format';
 
 
+// Watchlist page: fetch all tickers and show only those saved via useWatchlist.
 export default function WatchlistPage() {
   const { list, remove } = useWatchlist();
   const tickers = React.useMemo(() => new Set<string>(Array.isArray(list) ? list : []), [list]);
 
-  const { data, isLoading, error } = useQuery<TickerQueryData>({
+  const { data, isLoading, error } = useQuery<TickerRow[]>({
     queryKey: TICKERS_QUERY_KEY,
-    queryFn: async () => (await api.get<TickerRow[]>('/tickers')).data,
+    queryFn: fetchTickers,
   });
 
-  const allRows: TickerRow[] = toTickerRows(data);
+  const allRows: TickerRow[] = data ?? [];
   const rows = allRows.filter(r => tickers.has(r.ticker));
+
 
   if (isLoading) {
     return (


### PR DESCRIPTION
### Summary

Centralize tickers fetch logic behind a shared client so Screener and Watchlist use the same data path.

- Add `fetchTickers()` and `fetchTickerMetrics()` to `src/features/tickers/client.ts`
- Update `ScreenerPage` to use `fetchTickers` with `TICKERS_QUERY_KEY`
- Update `WatchlistPage` to use `fetchTickers` with `TICKERS_QUERY_KEY` and reuse the same normalized rows pattern

Behavior should be unchanged; this just prepares the codebase for a future static demo vs API-backed setup.

### Testing

- `npm run test`
- `npm run lint`
- `npm run build`

Closes #30 