### PR TITLE
feat(data): serve static fixtures in prod demo (#15)

### DIFF
--- a/src/features/tickers/TickerDetailPage.tsx
+++ b/src/features/tickers/TickerDetailPage.tsx
@@ -1,6 +1,6 @@
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
-import { api } from '../../lib/api';
+import { fetchTickerMetrics } from './client';
 import type { TickerMetrics } from '../../lib/types';
 import { Card, Row, Col, Spinner, Alert, Badge, Button, Stack } from 'react-bootstrap';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
@@ -28,10 +28,7 @@ export default function TickerDetailPage() {
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['ticker', symbol],
-    queryFn: async () => {
-      const res = await api.get<TickerMetrics>(`/tickers/${symbol}`);
-      return res.data;
-    },
+    queryFn: () => fetchTickerMetrics(symbol),
     enabled: Boolean(symbol),
     retry: false,
   });

--- a/src/features/tickers/client.ts
+++ b/src/features/tickers/client.ts
@@ -1,15 +1,30 @@
 import { api } from '../../lib/api';
 import type { TickerRow, TickerMetrics } from '../../lib/types';
 import { toTickerRows, type TickerQueryData } from './query';
+import { tickerFixtures, findOrCreateMetrics } from '../../mocks/fixtures';
 
 // Centralized tickers fetcher so Screener, Watchlist, and Ticker Detail
+// can stay unaware of whether data is coming from MSW (dev) or static fixtures (prod demo).
+const isProd = import.meta.env.PROD;
+
 export async function fetchTickers(): Promise<TickerRow[]> {
+  if (isProd) {
+    // In the production demo, avoid any real backend and serve static data.
+    // return a shallow copy so callers can't accidentally mutate fixtures.
+    return tickerFixtures.slice();
+  }
+
   const res = await api.get<TickerRow[] | { rows: TickerRow[] }>('/tickers');
   const data = res.data as TickerQueryData;
   return toTickerRows(data);
 }
 
 export async function fetchTickerMetrics(symbol: string): Promise<TickerMetrics> {
+  if (isProd) {
+    // In the production demo, lookup or synthesize metrics from fixtures.
+    return findOrCreateMetrics(symbol);
+  }
+
   const res = await api.get<TickerMetrics>(`/tickers/${symbol}`);
   return res.data;
 }

--- a/src/mocks/fixtures.ts
+++ b/src/mocks/fixtures.ts
@@ -1,0 +1,55 @@
+import tickers from './data/tickers.json';
+import metrics from './data/metrics.json';
+import type { TickerRow, TickerMetrics } from '../lib/types';
+
+// Typed fixture lists used by MSW and prod demo
+export const tickerFixtures = tickers as TickerRow[];
+export const metricsFixtures = metrics as TickerMetrics[];
+
+const norm = (s: unknown) => String(s ?? '').trim().toUpperCase();
+
+type SeriesPoint = TickerMetrics['series'][number];
+
+function makeSeries(days = 60, startPrice = 100): SeriesPoint[] {
+  const out: SeriesPoint[] = [];
+  let price = startPrice;
+
+  for (let i = days - 1; i >= 0; i--) {
+    const d = new Date();
+    d.setDate(d.getDate() - i);
+
+    // Small random walk around the base price
+    const delta = (Math.random() - 0.5) * 2; // roughly [-1, 1]
+    price = Math.max(1, price + delta);
+
+    out.push({
+      t: d.toISOString().slice(0, 10),
+      price: Number(price.toFixed(2)),
+      // Rough intra-day volume – just for chart/tooltips if we ever use it
+      vol: Math.floor(5_000 + Math.random() * 25_000),
+    });
+  }
+
+  return out;
+}
+
+function makeMetrics(ticker: string): TickerMetrics {
+  const base = 50 + Math.random() * 150; // 50–200
+
+  return {
+    ticker,
+    siPublic: Number((Math.random() * 20).toFixed(1)),
+    siBroad: Number((Math.random() * 30).toFixed(1)),
+    dtc: Number((Math.random() * 5).toFixed(1)),
+    rvol30d: Number((0.8 + Math.random() * 2.4).toFixed(1)),
+    squeezeScore: Math.floor(Math.random() * 100),
+    series: makeSeries(60, base),
+  };
+}
+
+// Lookup helper that prefers the static fixtures but can synthesize metrics
+export function findOrCreateMetrics(symbol: string): TickerMetrics {
+  const target = norm(symbol);
+  const hit = metricsFixtures.find(m => norm(m.ticker) === target);
+  return hit ?? makeMetrics(target);
+}

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,66 +1,26 @@
 import { http, HttpResponse } from 'msw';
-import tickers from './data/tickers.json';
-import metrics from './data/metrics.json';
-
-type SeriesPoint = { t: string; price: number };
-type TickerMetrics = {
-  ticker: string;
-  siPublic: number;
-  siBroad: number;
-  dtc: number;
-  rvol30d: number;
-  squeezeScore: number;
-  series: SeriesPoint[];
-};
+import { tickerFixtures, findOrCreateMetrics } from './fixtures';
 
 const DELAY_MS = 0;
 
 const norm = (s: unknown) => String(s ?? '').trim().toUpperCase();
 
-function makeSeries(days = 60, startPrice = 100): SeriesPoint[] {
-  const out: SeriesPoint[] = [];
-  let price = startPrice;
-  for (let i = days - 1; i >= 0; i--) {
-    const d = new Date();
-    d.setDate(d.getDate() - i);
-    const delta = (Math.random() - 0.5) * 2; // ~[-1, 1]
-    price = Math.max(1, price + delta);
-    out.push({ t: d.toISOString().slice(0, 10), price: Number(price.toFixed(2)) });
-  }
-  return out;
-}
-
-function makeMetrics(ticker: string): TickerMetrics {
-  const base = 50 + Math.random() * 150; // 50–200
-  return {
-    ticker,
-    siPublic: Number((Math.random() * 20).toFixed(1)),
-    siBroad: Number((Math.random() * 30).toFixed(1)),
-    dtc: Number((Math.random() * 5).toFixed(1)),
-    rvol30d: Number((0.8 + Math.random() * 2.4).toFixed(1)),
-    squeezeScore: Math.floor(Math.random() * 100),
-    series: makeSeries(60, base),
-  };
-}
-
-function findOrCreateMetrics(symbol: string): TickerMetrics {
-  const target = norm(symbol);
-  const hit = (metrics as TickerMetrics[]).find(m => norm(m.ticker) === target);
-  return hit ?? makeMetrics(target);
-}
-
 export const handlers = [
+  // List tickers – used by Screener and Watchlist via fetchTickers
   http.get('/api/tickers', async () => {
     if (DELAY_MS) await new Promise(r => setTimeout(r, DELAY_MS));
-    return HttpResponse.json(tickers, { status: 200 });
+    return HttpResponse.json(tickerFixtures, { status: 200 });
   }),
 
+  // Detail metrics – used by Ticker Detail via fetchTickerMetrics
   http.get('/api/tickers/:symbol', async ({ params }) => {
     const symbol = norm(params.symbol);
     if (!symbol) {
       return HttpResponse.json({ message: 'Missing symbol' }, { status: 400 });
     }
+
     if (DELAY_MS) await new Promise(r => setTimeout(r, DELAY_MS));
+
     const m = findOrCreateMetrics(symbol);
     return HttpResponse.json(m, { status: 200 });
   }),


### PR DESCRIPTION
# feat(data): serve static fixtures in prod demo (#15)

## Summary

Implements the core of Issue #15 by making the tickers data layer environment-aware:

- **Dev:** keep the existing MSW + Axios flow for `/api/tickers` and `/api/tickers/:symbol`.
- **Prod:** avoid any backend/MSW dependency and serve a static demo via typed fixtures.

Screener, Watchlist, and Ticker Detail continue to use the centralized tickers client and are unaware of where the data comes from.

## Changes

- **mocks**
  - Added `src/mocks/fixtures.ts`:
    - Exports `tickerFixtures: TickerRow[]` and `metricsFixtures: TickerMetrics[]` based on existing JSON data.
    - Provides `findOrCreateMetrics(symbol)` that either returns fixture metrics or synthesizes realistic values (including a 60-day price/volume series).
  - Updated `src/mocks/handlers.ts`:
    - `/api/tickers` now returns `tickerFixtures`.
    - `/api/tickers/:symbol` uses `findOrCreateMetrics(symbol)` from `fixtures.ts`.
    - Removes duplicated `TickerMetrics` and series helpers in favor of the shared implementation.

- **tickers client**
  - Updated `src/features/tickers/client.ts`:
    - Introduced an `isProd` flag via `import.meta.env.PROD`.
    - **Dev:** `fetchTickers` / `fetchTickerMetrics` call Axios (`/tickers`, `/tickers/:symbol`) and rely on MSW.
    - **Prod:** `fetchTickers` returns a shallow copy of `tickerFixtures`; `fetchTickerMetrics(symbol)` uses `findOrCreateMetrics(symbol)`.
    - Keeps the same async signature so React Query usage stays unchanged.

- **ticker detail**
  - Updated `src/features/tickers/TickerDetailPage.tsx`:
    - Swapped the inline `api.get` call in the React Query `queryFn` for `fetchTickerMetrics(symbol)` from the centralized client.
    - Ticker Detail now benefits from the same dev/prod switching as Screener and Watchlist.

## Dev vs Prod behavior

- **Development**
  - MSW is enabled and intercepts `/api/tickers` + `/api/tickers/:symbol`.
  - The client uses Axios and still exercises the “API layer” for DX realism.
- **Production**
  - MSW is not started.
  - The client bypasses Axios and uses static fixtures for tickers and metrics.
  - The demo is fully self-contained with no backend dependency.

## Testing

- `npm run lint`
- `npm run test`
- `npm run build`

Closes #15 