### PR TITLE
fix(data): avoid re-fetch on window focus (#34)

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,7 +7,14 @@ import { ErrorBoundary } from './components/ui/ErrorBoundary';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './styles/globals.css';
 
-const qc = new QueryClient();
+const qc = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Avoid surprise re-fetches when switching back to the tab.
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 
 async function prepare() {
   const enableMock =


### PR DESCRIPTION
## Summary

Disable React Query's `refetchOnWindowFocus` behavior to prevent data from disappearing when switching away from and back to the SqueezeScope tab in dev.

## Changes

- Configure the global `QueryClient` in `src/main.tsx` with:
  - `defaultOptions.queries.refetchOnWindowFocus = false`.

## Testing

- `npm run lint`
- `npm run test`
- `npm run build`

Closes #34