### PR TITLE
feat(ui): refine watchlist table hover and catalyst badge (#18)

### DIFF
--- a/src/features/watchlists/WatchlistPage.tsx
+++ b/src/features/watchlists/WatchlistPage.tsx
@@ -65,11 +65,13 @@ export default function WatchlistPage() {
 
       <Table
         className="table-sticky ss-compact ss-lines ss-hover"
+        striped
+        hover
         variant="dark"
         size="sm"
         responsive
-        striped
       >
+
         <thead>
           <tr>
             <th scope="col" className="text-start">Ticker</th>
@@ -104,8 +106,9 @@ export default function WatchlistPage() {
 
 
               <td className="text-start col-fit">
-                {r.catalyst ? <Badge bg="info" className="text-dark">Catalyst</Badge> : '—'}
+                {r.catalyst ? <Badge bg="warning" text="dark">Yes</Badge> : '—'}
               </td>
+
 
               <td className="text-start col-fit">
                 <Button


### PR DESCRIPTION
## Summary

Small Watchlist polish to better match the Screener’s tone and behavior.

## Changes

- Add `hover` to the Watchlist `<Table>` so row hover behavior matches the Screener.
- Align the Catalyst column with the Screener:
  - Use a `warning` badge with `text="dark"`.
  - Display `Yes` for catalyst tickers and `—` otherwise.

These changes are layered on top of the existing compact spacing, dividers, and empty state, so the Watchlist now feels consistent with the Screener.

## Testing

- `npm run lint`
- `npm run test`
- `npm run build`

Closes #18 