### PR TITLE
feat(screener): add SqueezeScore helper and screener column (#39)

### DIFF
--- a/src/features/tickers/ScreenerPage.tsx
+++ b/src/features/tickers/ScreenerPage.tsx
@@ -147,10 +147,12 @@ export default function ScreenerPage() {
               <option value="siBroad">SI% Broad</option>
               <option value="rvol">RVOL</option>
               <option value="dtc">DTC</option>
+              <option value="squeezeScore">Squeeze Score</option>
               <option value="pctChange">% Change</option>
               <option value="price">Price</option>
             </Form.Select>
           </Form.Group>
+
 
           <Col md="auto">
             <Form.Label>Sort Direction</Form.Label>

--- a/src/features/tickers/__tests__/squeezeScore.test.ts
+++ b/src/features/tickers/__tests__/squeezeScore.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import type { TickerRow } from "../../../lib/types";
+import { computeSqueezeScore } from "../squeezeScore";
+
+function makeRow(partial: Partial<TickerRow>): TickerRow {
+  return {
+    ticker: "TEST",
+    price: 10,
+    pctChange: 0,
+    siPublic: 0,
+    siBroad: 0,
+    dtc: 0,
+    rvol: 1,
+    catalyst: false,
+    ...partial,
+  };
+}
+
+describe("computeSqueezeScore", () => {
+  it("returns 0 for a very low-risk setup", () => {
+    const row = makeRow({
+      siPublic: 0,
+      siBroad: 0,
+      dtc: 0,
+      rvol: 0,
+      catalyst: false,
+    });
+
+    const score = computeSqueezeScore(row);
+
+    expect(score).toBe(0);
+  });
+
+  it("returns a mid-range score for moderate values without catalyst", () => {
+    const row = makeRow({
+      siPublic: 25, // 0.5 normalized
+      siBroad: 25, // 0.5 normalized
+      dtc: 5, // 0.5 normalized
+      rvol: 2.5, // 0.5 normalized
+      catalyst: false,
+    });
+
+    const score = computeSqueezeScore(row);
+
+    // 0.5 SI, 0.5 DTC, 0.5 RVOL → base 0.5 → score ≈ 50
+    expect(score).toBeCloseTo(50, 5);
+  });
+
+  it("applies a small boost when catalyst is true", () => {
+    const withoutCatalyst = makeRow({
+      siPublic: 25,
+      siBroad: 25,
+      dtc: 5,
+      rvol: 2.5,
+      catalyst: false,
+    });
+
+    const withCatalyst = makeRow({
+      siPublic: 25,
+      siBroad: 25,
+      dtc: 5,
+      rvol: 2.5,
+      catalyst: true,
+    });
+
+    const baseScore = computeSqueezeScore(withoutCatalyst);
+    const boostedScore = computeSqueezeScore(withCatalyst);
+
+    // Catalyst adds a small bump, not a huge jump.
+    expect(boostedScore).toBeGreaterThan(baseScore);
+    expect(boostedScore - baseScore).toBeCloseTo(5, 1); // ~5 points
+  });
+
+  it("caps extremely high values at 100", () => {
+    const row = makeRow({
+      siPublic: 80, // > 50 → normalized to 1
+      siBroad: 90, // > 50 → normalized to 1
+      dtc: 20, // > 10 → normalized to 1
+      rvol: 10, // > 5 → normalized to 1
+      catalyst: true,
+    });
+
+    const score = computeSqueezeScore(row);
+
+    // Raw score would exceed 100, but we clamp to the 0–100 range.
+    expect(score).toBe(100);
+  });
+});

--- a/src/features/tickers/components/ScreenerTable.tsx
+++ b/src/features/tickers/components/ScreenerTable.tsx
@@ -9,7 +9,9 @@ import {
   formatPercentChange,
   formatPercent1,
   formatOneDecimal,
+  formatScore,
 } from '../format';
+import { computeSqueezeScore } from '../squeezeScore';
 
 
 /**
@@ -42,6 +44,7 @@ const COLUMNS: ReadonlyArray<{ label: string; col: SortKey }> = [
   { label: 'SI% (Broad)', col: 'siBroad' },
   { label: 'DTC', col: 'dtc' },
   { label: 'RVOL', col: 'rvol' },
+  { label: 'Score', col: 'squeezeScore' },
 ];
 
 export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) {
@@ -106,7 +109,7 @@ export default function ScreenerTable({ rows, activeSort, dir, onSort }: Props) 
               <td>{formatPercent1(r.siBroad)}</td>
               <td>{formatOneDecimal(r.dtc)}</td>
               <td>{formatOneDecimal(r.rvol)}</td>
-
+              <td>{formatScore(computeSqueezeScore(r))}</td>
 
               {/* Catalyst: use a badge for quick scanning; fallback em dash when false. */}
               <td>{r.catalyst ? <Badge bg="warning" text="dark">Yes</Badge> : '—'}</td>

--- a/src/features/tickers/format.ts
+++ b/src/features/tickers/format.ts
@@ -1,21 +1,27 @@
 export function formatPrice(value: number | null | undefined): string {
-  if (value == null || Number.isNaN(value)) return '—';
+  if (value == null || Number.isNaN(value)) return "—";
   return value.toFixed(2);
 }
 
 export function formatPercentChange(value: number | null | undefined): string {
-  if (value == null || Number.isNaN(value)) return '—';
+  if (value == null || Number.isNaN(value)) return "—";
 
-  const sign = value > 0 ? '+' : value < 0 ? '' : '';
+  const sign = value > 0 ? "+" : value < 0 ? "" : "";
   return `${sign}${value.toFixed(2)}%`;
 }
 
 export function formatPercent1(value: number | null | undefined): string {
-  if (value == null || Number.isNaN(value)) return '—';
+  if (value == null || Number.isNaN(value)) return "—";
   return `${value.toFixed(1)}%`;
 }
 
 export function formatOneDecimal(value: number | null | undefined): string {
-  if (value == null || Number.isNaN(value)) return '—';
+  if (value == null || Number.isNaN(value)) return "—";
   return value.toFixed(1);
+}
+
+export function formatScore(value: number | null | undefined): string {
+  if (value == null || Number.isNaN(value)) return "—";
+  // SqueezeScore is a 0–100 integer; round to avoid noisy decimals.
+  return Math.round(value).toString();
 }

--- a/src/features/tickers/screenerSchema.ts
+++ b/src/features/tickers/screenerSchema.ts
@@ -1,36 +1,37 @@
-import { z } from 'zod';
+import { z } from "zod";
 
 /**
  * Supported keys to sort the list of stocks by a given metric.
  */
 export const sortKeys = [
-  'ticker',
-  'siPublic',
-  'siBroad',
-  'dtc',
-  'rvol',
-  'pctChange',
-  'price',
+  "ticker",
+  "siPublic",
+  "siBroad",
+  "rvol",
+  "dtc",
+  "squeezeScore",
+  "pctChange",
+  "price",
 ] as const;
 
-export type SortKey = typeof sortKeys[number];
+export type SortKey = (typeof sortKeys)[number];
 
 /** Sort direction */
-export const dirKeys = ['asc', 'desc'] as const;
-export type Dir = typeof dirKeys[number];
+export const dirKeys = ["asc", "desc"] as const;
+export type Dir = (typeof dirKeys)[number];
 
 /**
  * Input schema (coerces & supplies defaults from URL/query).
  * Keys are optional *on input* so we can parse raw URL strings.
  */
 export const ScreenerInputSchema = z.object({
-  q: z.string().trim().optional().default(''),
+  q: z.string().trim().optional().default(""),
   siMin: z.coerce.number().min(0).max(100).default(0),
   dtcMin: z.coerce.number().min(0).max(10).default(0),
   rvolMin: z.coerce.number().min(0).max(10).default(0),
   catalyst: z.coerce.boolean().default(false),
-  sort: z.enum(sortKeys).default('ticker'),
-  dir: z.enum(dirKeys).default('asc'),
+  sort: z.enum(sortKeys).default("ticker"),
+  dir: z.enum(dirKeys).default("asc"),
 });
 
 /**

--- a/src/features/tickers/sort.ts
+++ b/src/features/tickers/sort.ts
@@ -1,17 +1,19 @@
 // Sorting utilities for the screener.
 
-import type { TickerRow } from '../../lib/types';
+import type { TickerRow } from "../../lib/types";
+import { computeSqueezeScore } from "./squeezeScore";
 
 export type SortKey =
-  | 'ticker'
-  | 'price'
-  | 'pctChange'
-  | 'siPublic'
-  | 'siBroad'
-  | 'dtc'
-  | 'rvol';
+  | "ticker"
+  | "price"
+  | "pctChange"
+  | "siPublic"
+  | "siBroad"
+  | "dtc"
+  | "rvol"
+  | "squeezeScore";
 
-export type SortDir = 'asc' | 'desc';
+export type SortDir = "asc" | "desc";
 
 // Derive the subset of keys on TickerRow whose values are number.
 type NumericKeys<T> = {
@@ -20,10 +22,10 @@ type NumericKeys<T> = {
 
 type NumericTickerKey = Extract<NumericKeys<TickerRow>, SortKey>;
 
-const orderFactor = (dir: SortDir) => (dir === 'asc' ? 1 : -1);
+const orderFactor = (dir: SortDir) => (dir === "asc" ? 1 : -1);
 
 const isNumericKey = (key: SortKey): key is NumericTickerKey =>
-  key !== 'ticker';
+  key !== "ticker";
 
 /** Compare by ticker (string) with direction. */
 function compareByTicker(dir: SortDir) {
@@ -35,8 +37,7 @@ function compareByTicker(dir: SortDir) {
 /** Compare by a numeric key with direction (no casts needed). */
 function compareByNumber(key: NumericTickerKey, dir: SortDir) {
   const factor = orderFactor(dir);
-  return (rowA: TickerRow, rowB: TickerRow) =>
-    (rowA[key] - rowB[key]) * factor;
+  return (rowA: TickerRow, rowB: TickerRow) => (rowA[key] - rowB[key]) * factor;
 }
 
 /**
@@ -48,6 +49,17 @@ export function sortRows(
   dir: SortDir
 ): TickerRow[] {
   if (rows.length <= 1) return rows.slice();
+
+  if (key === "squeezeScore") {
+    // Sort by computed SqueezeScore (0–100), high to low or low to high.
+    return [...rows].sort((a, b) => {
+      const aScore = computeSqueezeScore(a);
+      const bScore = computeSqueezeScore(b);
+
+      if (aScore === bScore) return 0;
+      return dir === "asc" ? aScore - bScore : bScore - aScore;
+    });
+  }
 
   return [...rows].sort(
     isNumericKey(key) ? compareByNumber(key, dir) : compareByTicker(dir)

--- a/src/features/tickers/squeezeScore.ts
+++ b/src/features/tickers/squeezeScore.ts
@@ -1,0 +1,47 @@
+import type { TickerRow } from "../../lib/types";
+
+/**
+ * Compute a 0–100 squeeze score from a TickerRow.
+ *
+ * This is intentionally simple for v1 and based only on:
+ * - short interest (% of public & broad float)
+ * - days-to-cover (short ratio)
+ * - relative volume
+ * - catalyst flag
+ *
+ * The formula can be iterated on later without changing UI components.
+ */
+export function computeSqueezeScore(row: TickerRow): number {
+  const { siPublic, siBroad, dtc, rvol, catalyst } = row;
+
+  // Normalize inputs into 0–1 bands with simple caps.
+  const siPublicNorm = clamp01((siPublic ?? 0) / 50); // 50%+ SI → maxed
+  const siBroadNorm = clamp01((siBroad ?? 0) / 50);
+  const dtcNorm = clamp01((dtc ?? 0) / 10); // 10+ days → maxed
+  const rvolNorm = clamp01((rvol ?? 0) / 5); // 5x RVOL → maxed
+
+  const siScore = (siPublicNorm + siBroadNorm) / 2;
+
+  // Simple weights for v1
+  const base =
+    siScore * 0.5 + // short interest: 50%
+    dtcNorm * 0.3 + // days-to-cover: 30%
+    rvolNorm * 0.2; // relative volume: 20%
+
+  // Small bump in score for catalyst
+  const catalystBoost = catalyst ? 0.05 : 0;
+
+  const score = (base + catalystBoost) * 100;
+  return clamp(score, 0, 100);
+}
+
+// Helper to clamp a number between min and max
+function clamp(value: number, min: number, max: number): number {
+  if (Number.isNaN(value)) return min;
+  return Math.min(max, Math.max(min, value));
+}
+
+function clamp01(value: number): number {
+  // Clamp to the [0, 1] range (unit interval).
+  return clamp(value, 0, 1);
+}


### PR DESCRIPTION
## Summary

Introduce a computed **SqueezeScore (0–100)** based on short interest, days-to-cover, relative volume, and catalyst, and surface it in the Screener as a sortable column.

This gives the screener a single, opinionated squeeze signal that can be discussed and tuned over time.

## Changes

- Add `computeSqueezeScore(row: TickerRow)` in `src/features/tickers/squeezeScore.ts`:
  - Normalizes `siPublic`, `siBroad`, `dtc`, and `rvol` into 0–1 bands.
  - Applies simple v1 weights (SI 50%, DTC 30%, RVOL 20%) plus a small catalyst bump.
  - Clamps the final score to the `[0, 100]` range.

- Add `formatScore` in `src/features/tickers/format.ts`:
  - Renders SqueezeScore as a rounded 0–100 integer.
  - Falls back to `'—'` for null/NaN input to match other formatters.

- Screener sorting:
  - Extend `sortKeys` / `SortKey` to include `'squeezeScore'`.
  - Update `sortRows` to special-case `key === 'squeezeScore'` and sort by `computeSqueezeScore(row)`.

- Screener UI:
  - Add a **Score** column to `ScreenerTable` and render `formatScore(computeSqueezeScore(row))`.
  - Add **Squeeze Score** to the Sort `<select>` in `ScreenerPage`, so users can sort by the score directly.

## Notes

- This PR wires SqueezeScore into the **Screener** only.
- Ticker Detail hero integration can follow in a small, focused PR that reuses the same `computeSqueezeScore` helper.

## Testing

- `npm run test`
- `npm run lint`
- `npm run build`

Closes #39 