### PR TITLE
feat(ticker): surface SqueezeScore in detail hero (#41)

### DIFF
--- a/src/features/tickers/TickerDetailPage.tsx
+++ b/src/features/tickers/TickerDetailPage.tsx
@@ -1,10 +1,13 @@
 import { useParams } from 'react-router-dom';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { fetchTickerMetrics } from './client';
-import type { TickerMetrics } from '../../lib/types';
+import type { TickerMetrics, TickerRow } from '../../lib/types';
 import { Card, Row, Col, Spinner, Alert, Badge, Button, Stack } from 'react-bootstrap';
 import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
 import { useWatchlist } from '../watchlists/useWatchlist';
+import { computeSqueezeScore, computeSqueezeScoreFromMetrics } from './squeezeScore';
+import { formatScore } from './format';
+import { TICKERS_QUERY_KEY } from './query';
 
 function hasMetrics(x: unknown): x is TickerMetrics {
   if (!x || typeof x !== 'object') return false;
@@ -15,16 +18,16 @@ function hasMetrics(x: unknown): x is TickerMetrics {
     typeof m.siBroad === 'number' &&
     typeof m.dtc === 'number' &&
     typeof m.rvol30d === 'number' &&
-    typeof m.squeezeScore === 'number' &&
     Array.isArray(m.series)
   );
-};
+}
 
 export default function TickerDetailPage() {
   const { symbol = '' } = useParams();
 
   // Hooks must run unconditionally on every render
   const { list, add, remove } = useWatchlist();
+  const queryClient = useQueryClient();
 
   const { data, isLoading, error } = useQuery({
     queryKey: ['ticker', symbol],
@@ -33,19 +36,38 @@ export default function TickerDetailPage() {
     retry: false,
   });
 
-  if (!symbol) return <Alert variant="warning">No symbol provided.</Alert>;
-  if (isLoading) return <Spinner animation="border" role="status" aria-label="Loading…" />;
+  if (!symbol) {
+    return <Alert variant="warning">No symbol provided.</Alert>;
+  }
+
+  if (isLoading) {
+    return <Spinner animation="border" role="status" aria-label="Loading…" />;
+  }
+
   if (error || !hasMetrics(data)) {
-    return <Alert variant="secondary">No data found for <strong>{symbol}</strong>.</Alert>;
-  };
+    return (
+      <Alert variant="secondary">
+        No data found for <strong>{symbol}</strong>.
+      </Alert>
+    );
+  }
 
   const m = data;
 
   // Derive latest price from the series if present
   const lastPrice =
-    Array.isArray(m.series) && m.series.length > 0 && typeof m.series[m.series.length - 1]?.price === 'number'
+    Array.isArray(m.series) &&
+      m.series.length > 0 &&
+      typeof m.series[m.series.length - 1]?.price === 'number'
       ? (m.series[m.series.length - 1].price as number)
       : undefined;
+
+  // Try to reuse the screener row for a consistent SqueezeScore; fall back to metrics.
+  const tickers = queryClient.getQueryData<TickerRow[]>(TICKERS_QUERY_KEY) ?? [];
+  const rowForSymbol = tickers.find((row) => row.ticker === m.ticker);
+  const squeezeScore = rowForSymbol
+    ? computeSqueezeScore(rowForSymbol)
+    : computeSqueezeScoreFromMetrics(m);
 
   const saved = Array.isArray(list) ? list.includes(m.ticker) : false;
   const toggleWatch = () => (saved ? remove(m.ticker) : add(m.ticker));
@@ -55,14 +77,21 @@ export default function TickerDetailPage() {
       {/* Hero strip: ticker + key facts + watch toggle */}
       <div className="d-flex flex-wrap justify-content-between align-items-center mb-3">
         <Stack direction="horizontal" gap={3} className="flex-wrap">
-          <h2 id="ticker-heading" className="mb-0">{m.ticker}</h2>
+          <h2 id="ticker-heading" className="mb-0">
+            {m.ticker}
+          </h2>
 
           {typeof lastPrice === 'number' && (
             <div className="text-secondary">${lastPrice.toFixed(2)}</div>
           )}
 
-          <Badge bg="dark" className="border">
-            Squeeze Score: <span className="ms-1 fw-semibold">{m.squeezeScore}</span>
+          <Badge
+            bg="dark"
+            className="border"
+            title="Computed SqueezeScore (0–100) using screener formula"
+          >
+            SqueezeScore:{' '}
+            <span className="ms-1 fw-semibold">{formatScore(squeezeScore)}</span>
           </Badge>
 
           <Badge bg="secondary" title="30-day relative volume">
@@ -75,7 +104,9 @@ export default function TickerDetailPage() {
             size="sm"
             variant={saved ? 'outline-danger' : 'primary'}
             onClick={toggleWatch}
-            aria-label={saved ? `Remove ${m.ticker} from watchlist` : `Add ${m.ticker} to watchlist`}
+            aria-label={
+              saved ? `Remove ${m.ticker} from watchlist` : `Add ${m.ticker} to watchlist`
+            }
           >
             {saved ? 'Remove from Watchlist' : 'Add to Watchlist'}
           </Button>
@@ -83,11 +114,21 @@ export default function TickerDetailPage() {
       </div>
 
       <Row className="g-3 mb-3">
-        <Col md><Card body>SI% Public: {m.siPublic.toFixed(1)}</Card></Col>
-        <Col md><Card body>SI% Broad: {m.siBroad.toFixed(1)}</Card></Col>
-        <Col md><Card body>DTC: {m.dtc.toFixed(1)}</Card></Col>
-        <Col md><Card body>RVOL(30d): {m.rvol30d.toFixed(1)}</Card></Col>
-        <Col md><Card body>Squeeze Score: {m.squeezeScore}</Card></Col>
+        <Col md>
+          <Card body>SI% Public: {m.siPublic.toFixed(1)}</Card>
+        </Col>
+        <Col md>
+          <Card body>SI% Broad: {m.siBroad.toFixed(1)}</Card>
+        </Col>
+        <Col md>
+          <Card body>DTC: {m.dtc.toFixed(1)}</Card>
+        </Col>
+        <Col md>
+          <Card body>RVOL(30d): {m.rvol30d.toFixed(1)}</Card>
+        </Col>
+        <Col md>
+          <Card body>SqueezeScore: {formatScore(squeezeScore)}</Card>
+        </Col>
       </Row>
 
       <Card body>

--- a/src/features/tickers/squeezeScore.ts
+++ b/src/features/tickers/squeezeScore.ts
@@ -1,15 +1,15 @@
-import type { TickerRow } from "../../lib/types";
+import type { TickerRow, TickerMetrics } from '../../lib/types';
 
 /**
- * Compute a 0–100 squeeze score from a TickerRow.
+ * Compute a 0–100 SqueezeScore from a TickerRow.
  *
- * This is intentionally simple for v1 and based only on:
- * - short interest (% of public & broad float)
- * - days-to-cover (short ratio)
- * - relative volume
- * - catalyst flag
+ * Inputs (v1):
+ * - siPublic / siBroad: short interest % (public vs broad float)
+ * - dtc: days-to-cover (short ratio)
+ * - rvol: relative volume
+ * - catalyst: recent news/filing flag
  *
- * The formula can be iterated on later without changing UI components.
+ * The formula is intentionally simple and can be tuned later without changing UI components.
  */
 export function computeSqueezeScore(row: TickerRow): number {
   const { siPublic, siBroad, dtc, rvol, catalyst } = row;
@@ -22,20 +22,42 @@ export function computeSqueezeScore(row: TickerRow): number {
 
   const siScore = (siPublicNorm + siBroadNorm) / 2;
 
-  // Simple weights for v1
+  // Simple weights for v1.
   const base =
     siScore * 0.5 + // short interest: 50%
     dtcNorm * 0.3 + // days-to-cover: 30%
     rvolNorm * 0.2; // relative volume: 20%
 
-  // Small bump in score for catalyst
   const catalystBoost = catalyst ? 0.05 : 0;
 
   const score = (base + catalystBoost) * 100;
   return clamp(score, 0, 100);
 }
 
-// Helper to clamp a number between min and max
+/**
+ * Compute SqueezeScore from TickerMetrics by adapting it to a TickerRow shape.
+ *
+ * For now we rely on the shared SI% and DTC fields and treat the rest as neutral.
+ * If TickerMetrics is extended (price, rvol, catalyst, etc.), update this adapter
+ * without touching the core scoring formula.
+ */
+export function computeSqueezeScoreFromMetrics(metrics: TickerMetrics): number {
+  const rowLike: TickerRow = {
+    ticker: metrics.ticker,
+    price: 0,
+    pctChange: 0,
+    siPublic: metrics.siPublic,
+    siBroad: metrics.siBroad,
+    dtc: metrics.dtc,
+    rvol: 1,         // neutral relative volume
+    catalyst: false, // no catalyst info at the metrics level (yet)
+  };
+
+  return computeSqueezeScore(rowLike);
+}
+
+// Helpers
+
 function clamp(value: number, min: number, max: number): number {
   if (Number.isNaN(value)) return min;
   return Math.min(max, Math.max(min, value));


### PR DESCRIPTION
## Summary

Surface the computed **SqueezeScore (0–100)** on the Ticker Detail page and unify the scoring logic with the Screener.

The Screener already uses `computeSqueezeScore(TickerRow)` as the single source of truth. This PR reuses that formula for the detail view so the score for a given ticker is consistent across the app.

## Changes

- Extend `src/features/tickers/squeezeScore.ts`:
  - Add `computeSqueezeScoreFromMetrics(metrics: TickerMetrics)`:
    - Adapts `TickerMetrics` into a `TickerRow`-like shape.
    - Reuses `computeSqueezeScore` so the scoring formula lives in one place.
  - Document that additional `TickerMetrics` fields (e.g., RVOL, catalyst) can be wired in later without changing the UI.

- Update `TickerDetailPage`:
  - Loosen the `hasMetrics` type guard to no longer require a `squeezeScore` field (we now compute it).
  - Use React Query’s `queryClient.getQueryData(TICKERS_QUERY_KEY)` to:
    - Look up the corresponding `TickerRow` from the Screener cache.
    - Prefer `computeSqueezeScore(rowForSymbol)` when available for an exact match with the Screener.
    - Fall back to `computeSqueezeScoreFromMetrics(metrics)` when the Screener data isn’t cached (e.g., deep link to `/ticker/:symbol`).

- Hero + metrics layout:
  - Replace usages of `m.squeezeScore` with `formatScore(squeezeScore)`.
  - Show a labeled **SqueezeScore** badge in the hero with a `0–100` scale.
  - Add a SqueezeScore card in the metrics row using the same formatted value.

## Result

- For tickers navigated from the Screener, the Ticker Detail SqueezeScore now matches the Screener Score column.
- For deep-linked tickers, the detail page still shows a SqueezeScore using the same core formula.

## Testing

- `npm run test`
- `npm run lint`
- `npm run build`

Closes #41 