### PR TITLE
fix(screener): prevent Catalyst label clipping on smaller viewports

### DIFF
--- a/src/components/Layout/AppShell.tsx
+++ b/src/components/Layout/AppShell.tsx
@@ -6,7 +6,7 @@ export default function AppShell() {
   return (
     <>
       <NavBar />
-      <Container className="py-4">
+      <Container className="py-4" fluid="lg">
         <Outlet />
       </Container>
     </>

--- a/src/components/Layout/NavBar.tsx
+++ b/src/components/Layout/NavBar.tsx
@@ -4,7 +4,7 @@ import { Link, NavLink } from 'react-router-dom'
 export default function NavBar() {
   return (
     <Navbar bg="dark" variant="dark" expand="sm">
-      <Container>
+      <Container fluid="lg">
         <Navbar.Brand as={Link} to="/">SqueezeScope</Navbar.Brand>
         <Navbar.Toggle />
         <Navbar.Collapse>

--- a/src/features/tickers/ScreenerPage.tsx
+++ b/src/features/tickers/ScreenerPage.tsx
@@ -88,7 +88,7 @@ export default function ScreenerPage() {
 
       <Form className="mb-3" noValidate onSubmit={(e) => e.preventDefault()}>
         <Row className="g-2 align-items-end">
-          <Form.Group as={Col} md={3} controlId="q">
+          <Form.Group as={Col} xs={12} md={4} controlId="q">
             <Form.Label>Search</Form.Label>
             <Form.Control
               placeholder="Ticker…"
@@ -98,7 +98,7 @@ export default function ScreenerPage() {
             />
           </Form.Group>
 
-          <Form.Group as={Col} md={2} controlId="siMin">
+          <Form.Group as={Col} xs={6} md={2} controlId="siMin">
             <Form.Label>SI% (min)</Form.Label>
             <Form.Control
               type="number"
@@ -109,7 +109,7 @@ export default function ScreenerPage() {
             />
           </Form.Group>
 
-          <Form.Group as={Col} md={2} controlId="dtcMin">
+          <Form.Group as={Col} xs={6} md={2} controlId="dtcMin">
             <Form.Label>DTC (min)</Form.Label>
             <Form.Control
               type="number"
@@ -120,7 +120,7 @@ export default function ScreenerPage() {
             />
           </Form.Group>
 
-          <Form.Group as={Col} md={2} controlId="rvolMin">
+          <Form.Group as={Col} xs={6} md={2} controlId="rvolMin">
             <Form.Label>RVOL (min)</Form.Label>
             <Form.Control
               type="number"
@@ -131,15 +131,18 @@ export default function ScreenerPage() {
             />
           </Form.Group>
 
-          <Form.Group as={Col} md={1} controlId="catalyst">
+          <Form.Group as={Col} xs={6} md="auto" controlId="catalyst" className="ms-md-auto d-flex align-items-end">
             <Form.Check
               type="checkbox"
               label="Catalyst"
+              className="mb-1"
               {...form.register('catalyst')}
             />
           </Form.Group>
+          </Row>
 
-          <Form.Group as={Col} md={2} controlId="sort">
+          <Row className="g-2 align-items-end mt-1">
+          <Form.Group as={Col} xs={12} md={3} controlId="sort">
             <Form.Label>Sort</Form.Label>
             <Form.Select {...form.register('sort')}>
               <option value="ticker">Ticker</option>
@@ -154,7 +157,7 @@ export default function ScreenerPage() {
           </Form.Group>
 
 
-          <Col md="auto">
+          <Col xs={12} md="auto" className="ms-md-auto">
             <Form.Label>Sort Direction</Form.Label>
             <div>
               <Button


### PR DESCRIPTION
## Description
This PR fixes a responsive layout issue in the Screener toolbar where the “Catalyst” checkbox label was clipped at narrower widths. It also improves alignment consistency (right-aligning Catalyst at `md+`) and updates layout containers to reduce excessive side gutters, resulting in a more balanced UI across breakpoints.

## Changes
- **Toolbar layout:** Adjusted toolbar sizing/layout to prevent label clipping and ensure intentional wrapping.
- **Alignment:** Right-aligned the Catalyst control at `md+` to better match the Sort Direction controls.
- **Layout containers:** Updated `AppShell` and `NavBar` containers to better utilize available width on medium/large viewports.

## Verification
### Automated
- [x] `npm run lint`
- [x] `npm run test`
- [x] `npm run build`

### Manual
- [x] Verified "Catalyst" label visibility at 375px, 768px, and 992px.
- [x] Confirmed toolbar stacking behavior is predictable and intentional.
- [x] Verified no regressions in filtering/sorting logic.
- [x] Confirmed horizontal scroll behavior on the data table remains intact.

## Related Issues
Closes #46